### PR TITLE
Fix docs generation with Clang

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright 2022-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2022-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
@@ -89,7 +89,7 @@ WARN_IF_DOC_ERROR      = YES
 WARN_NO_PARAMDOC       = NO
 WARN_FORMAT            = "$file:$line: $text"
 WARN_LOGFILE           =
-INPUT                  =
+INPUT                  = @PROJECT_SOURCE_DIR@/src
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.c \
                          *.cpp \


### PR DESCRIPTION
Build process would crash when docs were generated using Clang

Change-Id: I4fc9813b1656782c5d06f07ede9bf6e6c08993db