### PR TITLE
Fetch the model-converter binary name from the compiled target

### DIFF
--- a/docs/redirect-output.cmake
+++ b/docs/redirect-output.cmake
@@ -1,0 +1,13 @@
+#
+# SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+#
+execute_process(
+  COMMAND "${cmd}" ${args}
+  WORKING_DIRECTORY ${wd}
+  OUTPUT_VARIABLE stdout
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  COMMAND_ERROR_IS_FATAL ANY
+)
+
+file(WRITE ${out} ${stdout})


### PR DESCRIPTION
Do not use a hard-coded name since it does not work cross-platform.

Also disable building docs when cross-compiling.
