### PR TITLE
Clang-tidy checker for naming and concatinating namespaces

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,6 +9,7 @@ Checks: >
     google-build-namespaces,
     misc-definitions-in-headers,
     misc-unused-*,
+    modernize-concat-nested-namespaces,
     modernize-deprecated-headers,
     modernize-make-unique,
     modernize-redundant-void-arg,
@@ -40,6 +41,7 @@ Checks: >
     readability-delete-null-pointer,
     readability-duplicate-include,
     readability-else-after-return,
+    readability-identifier-naming,
     readability-isolate-declaration,
     readability-make-member-function-const,
     readability-misleading-indentation,
@@ -67,3 +69,10 @@ Checks: >
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 FormatStyle: file
+CheckOptions:
+  - key: readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key: readability-identifier-naming.LocalVariableCase
+    value: camelBack
+  - key: readability-identifier-naming.StructCase
+    value: CamelCase

--- a/src/conversion/check_sparsity.cpp
+++ b/src/conversion/check_sparsity.cpp
@@ -8,8 +8,7 @@
 
 #include <numeric>
 
-namespace mlir {
-namespace model_converter_passes {
+namespace mlir::model_converter_passes {
 #define GEN_PASS_DEF_CHECKCONSTANTSPARSITYPASS
 #include "passes.hpp.inc"
 namespace {
@@ -113,5 +112,4 @@ bool CheckConstantSparsityPass::checkSparsityLoop(const T *data, int64_t otherDi
 
 } // namespace
 
-} // namespace model_converter_passes
-} // namespace mlir
+} // namespace mlir::model_converter_passes

--- a/src/conversion/model_partition_marking.cpp
+++ b/src/conversion/model_partition_marking.cpp
@@ -7,8 +7,7 @@
 
 #include <algorithm>
 
-namespace mlir {
-namespace model_converter_passes {
+namespace mlir::model_converter_passes {
 #define GEN_PASS_DEF_MODELPARTITIONMARKINGPASS
 #include "passes.hpp.inc"
 namespace {
@@ -88,5 +87,4 @@ class ModelPartitionMarkingPass : public impl::ModelPartitionMarkingPassBase<Mod
 
 } // namespace
 
-} // namespace model_converter_passes
-} // namespace mlir
+} // namespace mlir::model_converter_passes

--- a/src/conversion/model_partitioning.cpp
+++ b/src/conversion/model_partitioning.cpp
@@ -17,8 +17,7 @@
 #include <queue>
 #include <vector>
 
-namespace mlir {
-namespace model_converter_passes {
+namespace mlir::model_converter_passes {
 #define GEN_PASS_DEF_MODELPARTITIONINGPASS
 #include "passes.hpp.inc"
 namespace {
@@ -299,17 +298,17 @@ void insertPartitionOpInMap(const int64_t id, Operation *op, DenseMap<int64_t, S
 }
 
 bool comparePartitionResultIndex(const Value &a, const Value &b) {
-    int64_t a_idx = 0;
-    int64_t b_idx = 0;
+    int64_t aIdx = 0;
+    int64_t bIdx = 0;
 
     if (auto attr = a.getDefiningOp()->getAttrOfType<IntegerAttr>("graph_partition_sequence_output_index")) {
-        a_idx = attr.getInt();
+        aIdx = attr.getInt();
     }
     if (auto attr = b.getDefiningOp()->getAttrOfType<IntegerAttr>("graph_partition_sequence_output_index")) {
-        b_idx = attr.getInt();
+        bIdx = attr.getInt();
     }
 
-    return a_idx < b_idx;
+    return aIdx < bIdx;
 }
 
 void insertPartitionResultInMap(const int64_t id, Value value, DenseMap<int64_t, SmallVector<Value>> &map) {
@@ -493,5 +492,4 @@ class ModelPartitioningPass : public impl::ModelPartitioningPassBase<ModelPartit
 
 } // namespace
 
-} // namespace model_converter_passes
-} // namespace mlir
+} // namespace mlir::model_converter_passes

--- a/src/conversion/serialize_vgf.cpp
+++ b/src/conversion/serialize_vgf.cpp
@@ -24,8 +24,7 @@
 
 using namespace mlsdk::vgflib;
 
-namespace mlir {
-namespace model_converter_passes {
+namespace mlir::model_converter_passes {
 #define GEN_PASS_DEF_SERIALIZEVGFPASS
 #include "passes.hpp.inc"
 namespace {
@@ -681,5 +680,4 @@ std::unique_ptr<Pass> createSerializeVGFPass(std::shared_ptr<VGFBuilder> VGFBuil
     return std::make_unique<SerializeVGFPass>(VGFBuilder, outputName, options);
 }
 
-} // namespace model_converter_passes
-} // namespace mlir
+} // namespace mlir::model_converter_passes

--- a/src/conversion/signless_integer_marking.cpp
+++ b/src/conversion/signless_integer_marking.cpp
@@ -5,8 +5,7 @@
 
 #include "include/passes.hpp"
 
-namespace mlir {
-namespace model_converter_passes {
+namespace mlir::model_converter_passes {
 #define GEN_PASS_DEF_SIGNLESSINTEGERMARKINGPASS
 #include "passes.hpp.inc"
 namespace {
@@ -24,15 +23,15 @@ class SignlessIntegerMarkingPass : public impl::SignlessIntegerMarkingPassBase<S
     mlir::LogicalResult SignlessIntegerMarking(mlir::func::FuncOp func) {
         MLIRContext *context = &getContext();
         const FunctionType funcType = func.getFunctionType();
-        StringRef unsigned_attr = "mlsdk.unsigned_input_output";
+        StringRef unsignedAttr = "mlsdk.unsigned_input_output";
 
         // set the default unsigned_input_output attribute for inputs
         for (unsigned i = 0; i < funcType.getNumInputs(); ++i) {
-            func.setArgAttr(i, unsigned_attr, BoolAttr::get(context, false));
+            func.setArgAttr(i, unsignedAttr, BoolAttr::get(context, false));
         }
         // set the default unsigned_input_output attribute for outputs
         for (unsigned i = 0; i < funcType.getNumResults(); ++i) {
-            func.setResultAttr(i, unsigned_attr, BoolAttr::get(context, false));
+            func.setResultAttr(i, unsignedAttr, BoolAttr::get(context, false));
         }
 
         // find rescale operations attached to input
@@ -42,7 +41,7 @@ class SignlessIntegerMarkingPass : public impl::SignlessIntegerMarkingPassBase<S
                     if (op.getInputUnsigned()) {
                         if (BlockArgument arg = llvm::dyn_cast<BlockArgument>(operand)) {
                             unsigned inputIndex = arg.getArgNumber();
-                            func.setArgAttr(inputIndex, unsigned_attr, BoolAttr::get(context, true));
+                            func.setArgAttr(inputIndex, unsignedAttr, BoolAttr::get(context, true));
                         }
                     }
                 }
@@ -55,7 +54,7 @@ class SignlessIntegerMarkingPass : public impl::SignlessIntegerMarkingPassBase<S
                 if (Operation *input = operand.getDefiningOp()) {
                     if (auto rescaleOp = llvm::dyn_cast_or_null<tosa::RescaleOp>(input)) {
                         if (rescaleOp.getOutputUnsigned()) {
-                            func.setResultAttr(static_cast<uint32_t>(index), unsigned_attr,
+                            func.setResultAttr(static_cast<uint32_t>(index), unsignedAttr,
                                                BoolAttr::get(context, true));
                         }
                     }
@@ -69,5 +68,4 @@ class SignlessIntegerMarkingPass : public impl::SignlessIntegerMarkingPassBase<S
 
 } // namespace
 
-} // namespace model_converter_passes
-} // namespace mlir
+} // namespace mlir::model_converter_passes

--- a/src/conversion/verify_shaped_tensors.cpp
+++ b/src/conversion/verify_shaped_tensors.cpp
@@ -8,8 +8,7 @@
 
 #include <memory>
 
-namespace mlir {
-namespace model_converter_passes {
+namespace mlir::model_converter_passes {
 #define GEN_PASS_DEF_TOSASHAPEDVERIFICATIONPASS
 #include "passes.hpp.inc"
 
@@ -77,20 +76,20 @@ class TosaShapedVerificationPass : public impl::TosaShapedVerificationPassBase<T
                 }
                 // Verify tensor has rank
                 if (!tensorType.hasRank()) {
-                    std::string _str;
-                    llvm::raw_string_ostream _stream(_str);
-                    _stream << "(unranked) " << tensorType << " in: " << operand;
-                    dynamicOps.push_back(_str);
+                    std::string str;
+                    llvm::raw_string_ostream stream(str);
+                    stream << "(unranked) " << tensorType << " in: " << operand;
+                    dynamicOps.push_back(str);
                     return;
                 }
 
                 // Verify all elements > 0
                 ArrayRef<int64_t> shape = tensorType.getShape();
                 if (!isRealizedShape(shape)) {
-                    std::string _str;
-                    llvm::raw_string_ostream _stream(_str);
-                    _stream << "(dynamic) " << tensorType << " in: " << operand;
-                    dynamicOps.push_back(_str);
+                    std::string str;
+                    llvm::raw_string_ostream stream(str);
+                    stream << "(dynamic) " << tensorType << " in: " << operand;
+                    dynamicOps.push_back(str);
                     return;
                 }
             }
@@ -122,5 +121,4 @@ class TosaShapedVerificationPass : public impl::TosaShapedVerificationPassBase<T
     }
 };
 
-} // namespace model_converter_passes
-} // namespace mlir
+} // namespace mlir::model_converter_passes

--- a/src/conversion/vgf_constants.cpp
+++ b/src/conversion/vgf_constants.cpp
@@ -14,8 +14,7 @@
 
 using namespace mlsdk::vgflib;
 
-namespace mlir {
-namespace model_converter_passes {
+namespace mlir::model_converter_passes {
 #define GEN_PASS_DEF_VGFCONSTANTSPASS
 #include "passes.hpp.inc"
 namespace {
@@ -103,5 +102,4 @@ std::unique_ptr<Pass> createVGFConstantsPass(std::shared_ptr<VGFBuilder> VGFBuil
     return std::make_unique<VGFConstantsPass>(VGFBuilder);
 }
 
-} // namespace model_converter_passes
-} // namespace mlir
+} // namespace mlir::model_converter_passes


### PR DESCRIPTION
Change-Id: I40d8c7e32addd398615d8c22bd0f105afdb6a103