### PR TITLE
Fix SPIR-V pass order for ABI lowering and VCE deduction

### DIFF
--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -123,8 +123,8 @@ void Compiler::SetPassManager() {
             OpPassManager &segmentNestedPM = sequenceNestedPM.nest<vgf::SegmentOp>();
             OpPassManager &spirvNestedPM = segmentNestedPM.nest<spirv::ModuleOp>();
             spirvNestedPM.addPass(mlir::spirv::createSPIRVReplicatedConstantCompositePass());
-            spirvNestedPM.addPass(mlir::spirv::createSPIRVUpdateVCEPass());
             spirvNestedPM.addPass(mlir::spirv::createSPIRVLowerABIAttributesPass());
+            spirvNestedPM.addPass(mlir::spirv::createSPIRVUpdateVCEPass());
 
             // Sequence Module Passes
             sequenceNestedPM.addPass(


### PR DESCRIPTION
Move SPIRVLowerABIAttributesPass before SPIRVUpdateVCEPass so VCE deduction runs on the ABI-lowered SPIR-V module.

This avoids stale vce_triple metadata for graph modules with Binding and DescriptorSet decorations and fixes the Shader capability validation failure seen without the temporary LLVM workaround.
