### PR TITLE
Assign GraphARM interface bindings before SPIR-V lowering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ add_public_tablegen_target(MLIRVGFAttributesIncGen)
 
 set(CONVERTER_PASS_LIB_SOURCES
     "src/conversion/check_sparsity.cpp"
+    "src/conversion/assign_grapharm_interface_var_abi.cpp"
     "src/conversion/dense_resource_inliner.cpp"
     "src/conversion/model_partition_marking.cpp"
     "src/conversion/model_partitioning.cpp"

--- a/cmake/llvm-project.cmake
+++ b/cmake/llvm-project.cmake
@@ -33,7 +33,7 @@ endfunction()
 
 if(EXISTS ${LLVM_PATH}/llvm/CMakeLists.txt)
     if(MODEL_CONVERTER_APPLY_LLVM_PATCH)
-        set(LLVM_PATCH_COMMIT_MESSAGE "llvm-changes-for-model-converter-24-04-2026")
+        set(LLVM_PATCH_COMMIT_MESSAGE "llvm-changes-for-model-converter-27-04-2026")
         execute_process(
             COMMAND git log --grep=${LLVM_PATCH_COMMIT_MESSAGE}
             WORKING_DIRECTORY "${LLVM_PATH}"

--- a/patches/llvm.patch
+++ b/patches/llvm.patch
@@ -1,6 +1,6 @@
 From: svc_sdk <svc_sdk@arm.com>
 Date: Thu Feb 19 00:00:00 2026
-Subject: llvm-changes-for-model-converter-24-04-2026
+Subject: llvm-changes-for-model-converter-27-04-2026
 
 diff --git a/mlir/include/mlir/Conversion/Passes.h b/mlir/include/mlir/Conversion/Passes.h
 index a54b98004c3b..499633994eb5 100644
@@ -396,7 +396,7 @@ new file mode 100644
 index 000000000000..3b26a077a0df
 --- /dev/null
 +++ b/mlir/lib/Conversion/TosaToSPIRV/TosaToSPIRV.cpp
-@@ -0,0 +1,136 @@
+@@ -0,0 +1,170 @@
 +//===- TosaToSPIRV.cpp - Tosa to SPIR-V Patterns --------------------------===//
 +//
 +// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -432,9 +432,47 @@ index 000000000000..3b26a077a0df
 +
 +namespace {
 +
++constexpr StringLiteral graphARMInterfaceVarABIAttrName =
++    "spv.grapharm.interface_var_abi";
++
 +struct FuncGraphConvert final : public TosaOpConversionPattern<func::FuncOp> {
 +  using TosaOpConversionPattern<func::FuncOp>::TosaOpConversionPattern;
 +
++private:
++  void setInterfaceVarABIAttr(spirv::GraphARMOp graphOp, MLIRContext *context,
++                              unsigned index, bool isResult,
++                              uint32_t defaultDescriptorSet,
++                              uint32_t defaultBinding) const {
++    auto abiInfo =
++        isResult ? graphOp.getResultAttrOfType<spirv::InterfaceVarABIAttr>(
++                       index, graphARMInterfaceVarABIAttrName)
++                 : graphOp.getArgAttrOfType<spirv::InterfaceVarABIAttr>(
++                       index, graphARMInterfaceVarABIAttrName);
++
++    if (!abiInfo) {
++      abiInfo = isResult
++                    ? graphOp.getResultAttrOfType<spirv::InterfaceVarABIAttr>(
++                          index, spirv::getInterfaceVarABIAttrName())
++                    : graphOp.getArgAttrOfType<spirv::InterfaceVarABIAttr>(
++                          index, spirv::getInterfaceVarABIAttrName());
++    }
++
++    if (!abiInfo) {
++      abiInfo = spirv::InterfaceVarABIAttr::get(
++          defaultDescriptorSet, defaultBinding, std::nullopt, context);
++    }
++
++    if (isResult) {
++      graphOp.setResultAttr(index, spirv::getInterfaceVarABIAttrName(),
++                            abiInfo);
++      graphOp.removeResultAttr(index, graphARMInterfaceVarABIAttrName);
++    } else {
++      graphOp.setArgAttr(index, spirv::getInterfaceVarABIAttrName(), abiInfo);
++      graphOp.removeArgAttr(index, graphARMInterfaceVarABIAttrName);
++    }
++  }
++
++public:
 +  LogicalResult
 +  matchAndRewrite(func::FuncOp funcOp, func::FuncOpAdaptor adaptor,
 +                  ConversionPatternRewriter &rewriter) const override {
@@ -490,20 +528,16 @@ index 000000000000..3b26a077a0df
 +        descriptorSet = static_cast<uint32_t>(descriptorSetAttr.getUInt());
 +      }
 +
-+      StringRef varABIAttrName = spirv::getInterfaceVarABIAttrName();
 +      unsigned inputs = ftype.getNumInputs();
 +      unsigned outputs = ftype.getNumResults();
++ 
 +      for (auto argIndex : llvm::seq<unsigned>(0, inputs)) {
-+        uint32_t binding = argIndex;
-+        auto abiInfo = spirv::InterfaceVarABIAttr::get(descriptorSet, binding,
-+                                                       std::nullopt, context);
-+        graphOp.setArgAttr(argIndex, varABIAttrName, abiInfo);
++        setInterfaceVarABIAttr(graphOp, context, argIndex, false, descriptorSet,
++                               argIndex);
 +      }
 +      for (auto resIndex : llvm::seq<unsigned>(0, outputs)) {
-+        uint32_t binding = resIndex + inputs;
-+        auto abiInfo = spirv::InterfaceVarABIAttr::get(descriptorSet, binding,
-+                                                       std::nullopt, context);
-+        graphOp.setResultAttr(resIndex, varABIAttrName, abiInfo);
++        setInterfaceVarABIAttr(graphOp, context, resIndex, true, descriptorSet,
++                               resIndex + inputs);
 +      }
 +    }
 +

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -115,6 +115,7 @@ void Compiler::SetPassManager() {
 
         _pm.addPass(createCheckConstantSparsityPass());
         _pm.addPass(createVGFConstantsPass(builder));
+        _pm.nest<vgf::SequenceOp>().addPass(createAssignGraphARMInterfaceVarABIPass());
         _pm.addPass(mlir::tosa::createTosaToSPIRV(_options.analysis));
 
         {

--- a/src/conversion/assign_grapharm_interface_var_abi.cpp
+++ b/src/conversion/assign_grapharm_interface_var_abi.cpp
@@ -1,0 +1,152 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+#include "include/passes.hpp"
+
+#include "llvm/ADT/STLExtras.h"
+
+namespace mlir::model_converter_passes {
+#define GEN_PASS_DEF_ASSIGNGRAPHARMINTERFACEVARABIPASS
+#include "passes.hpp.inc"
+namespace {
+
+constexpr StringLiteral graphARMInterfaceVarABIAttrName = "spv.grapharm.interface_var_abi";
+constexpr uint32_t graphARMDescriptorSet = 0;
+
+class AssignGraphARMInterfaceVarABIPass
+    : public impl::AssignGraphARMInterfaceVarABIPassBase<AssignGraphARMInterfaceVarABIPass> {
+  public:
+    using impl::AssignGraphARMInterfaceVarABIPassBase<
+        AssignGraphARMInterfaceVarABIPass>::AssignGraphARMInterfaceVarABIPassBase;
+
+    void runOnOperation() override {
+        if (failed(assignInterfaceVarABI(getOperation()))) {
+            signalPassFailure();
+        }
+    }
+
+  private:
+    uint32_t getBindingId(const DenseMap<Value, uint32_t> &bindingIds, Value value) {
+        auto it = bindingIds.find(value);
+        assert(it != bindingIds.end() && "expected binding for graph interface value");
+        return it->second;
+    }
+
+    spirv::InterfaceVarABIAttr getInterfaceVarABIAttr(uint32_t bindingId) {
+        return spirv::InterfaceVarABIAttr::get(graphARMDescriptorSet, bindingId, std::nullopt, &getContext());
+    }
+
+    LogicalResult assignInterfaceVarABI(vgf::SequenceOp sequenceOp) {
+        auto isSequenceInputOperand = [&](Value operand) {
+            return llvm::is_contained(sequenceOp.getArguments(), operand);
+        };
+
+        Operation *sequenceOutputOp = sequenceOp.front().getTerminator();
+        auto isSequenceOutputOperand = [&](Value operand) {
+            return llvm::is_contained(sequenceOutputOp->getOperands(), operand);
+        };
+
+        DenseMap<Value, uint32_t> bindingIds;
+        auto assignBindingIfUnset = [&](Value operand, uint32_t bindingId) {
+            bindingIds.try_emplace(operand, bindingId);
+        };
+
+        // First: Resolve sequence inputs.
+        for (BlockArgument operand : sequenceOp.getArguments()) {
+            sequenceOp.walk([&](vgf::SegmentOp segmentOp) {
+                Operation *runSegmentOp = segmentOp->getNextNode();
+                if (runSegmentOp && llvm::is_contained(runSegmentOp->getOperands(), operand)) {
+                    assignBindingIfUnset(operand, static_cast<uint32_t>(operand.getArgNumber()));
+                }
+            });
+        }
+
+        // Second: Resolve intermediate values.
+        auto bindingId = static_cast<uint32_t>(sequenceOp.getNumArguments());
+        WalkResult sequenceWalkResult = sequenceOp.walk([&](vgf::SegmentOp segmentOp) {
+            Operation *runSegmentOp = segmentOp->getNextNode();
+            if (!runSegmentOp) {
+                return WalkResult::advance();
+            }
+
+            for (Value operand : runSegmentOp->getOperands()) {
+                if (!isSequenceInputOperand(operand) && !bindingIds.contains(operand)) {
+                    bindingIds[operand] = bindingId++;
+                }
+            }
+            for (Value result : runSegmentOp->getResults()) {
+                if (!isSequenceOutputOperand(result) && !bindingIds.contains(result)) {
+                    bindingIds[result] = bindingId++;
+                }
+            }
+            return WalkResult::advance();
+        });
+        if (sequenceWalkResult.wasInterrupted()) {
+            return failure();
+        }
+
+        // Third: Resolve sequence outputs.
+        for (Value operand : sequenceOutputOp->getOperands()) {
+            sequenceOp.walk([&](vgf::SegmentOp segmentOp) {
+                Operation *runSegmentOp = segmentOp->getNextNode();
+                if (runSegmentOp && llvm::is_contained(runSegmentOp->getResults(), operand) &&
+                    !bindingIds.contains(operand)) {
+                    bindingIds[operand] = bindingId++;
+                }
+            });
+        }
+
+        sequenceWalkResult = sequenceOp.walk([&](vgf::SegmentOp segmentOp) {
+            if (segmentOp.getSegmentType() != vgf::SegmentTypeEnum::GRAPH) {
+                return WalkResult::advance();
+            }
+
+            Operation *runSegmentOp = segmentOp->getNextNode();
+            if (!runSegmentOp) {
+                segmentOp.emitError("expected graph segment to be followed by a segment run op");
+                return WalkResult::interrupt();
+            }
+
+            auto funcRange = segmentOp.getOps<func::FuncOp>();
+            auto funcIt = funcRange.begin();
+            if (funcIt == funcRange.end()) {
+                segmentOp.emitError("expected graph segment to contain a func.func");
+                return WalkResult::interrupt();
+            }
+            func::FuncOp funcOp = *funcIt;
+            ++funcIt;
+            if (funcIt != funcRange.end()) {
+                segmentOp.emitError("expected graph segment to contain a single func.func");
+                return WalkResult::interrupt();
+            }
+
+            if (runSegmentOp->getNumOperands() != funcOp.getNumArguments()) {
+                funcOp.emitError("segment run operand count does not match graph function arguments");
+                return WalkResult::interrupt();
+            }
+            if (runSegmentOp->getNumResults() != funcOp.getNumResults()) {
+                funcOp.emitError("segment run result count does not match graph function results");
+                return WalkResult::interrupt();
+            }
+
+            for (auto [argIndex, operand] : llvm::enumerate(runSegmentOp->getOperands())) {
+                funcOp.setArgAttr(static_cast<unsigned>(argIndex), graphARMInterfaceVarABIAttrName,
+                                  getInterfaceVarABIAttr(getBindingId(bindingIds, operand)));
+            }
+
+            for (auto [resultIndex, result] : llvm::enumerate(runSegmentOp->getResults())) {
+                funcOp.setResultAttr(static_cast<unsigned>(resultIndex), graphARMInterfaceVarABIAttrName,
+                                     getInterfaceVarABIAttr(getBindingId(bindingIds, result)));
+            }
+
+            return WalkResult::advance();
+        });
+
+        return sequenceWalkResult.wasInterrupted() ? failure() : success();
+    }
+};
+
+} // namespace
+} // namespace mlir::model_converter_passes

--- a/src/conversion/serialize_vgf.cpp
+++ b/src/conversion/serialize_vgf.cpp
@@ -46,34 +46,6 @@ std::optional<ShaderType> toShaderType(const StringRef language) {
     return std::nullopt;
 }
 
-void setGlobalVarOpBindingAndDescriptorSet(spirv::GraphARMOp opGraph, Value operand, uint32_t bindingId) {
-    auto *runSegmentOp = opGraph->getParentOp()->getParentOp()->getNextNode();
-    if (auto moduleOp = llvm::dyn_cast<spirv::ModuleOp>(opGraph->getParentOp())) {
-
-        SmallVector<Value> rangeOperandsAndResults = ValueRange(runSegmentOp->getOperands());
-        rangeOperandsAndResults.append(runSegmentOp->getResults().begin(), runSegmentOp->getResults().end());
-
-        auto *it = std::find(rangeOperandsAndResults.begin(), rangeOperandsAndResults.end(), operand);
-        if (it == rangeOperandsAndResults.end()) {
-            return;
-        }
-        auto operandInterfaceId = std::distance(rangeOperandsAndResults.begin(), it);
-
-        auto graphEntryPointOp = *moduleOp.getBody()->getOps<spirv::GraphEntryPointARMOp>().begin();
-        for (auto globalVarOp : moduleOp.getBody()->getOps<spirv::GlobalVariableOp>()) {
-            if (globalVarOp.getNameAttr().getValue() ==
-                llvm::cast<FlatSymbolRefAttr>(
-                    graphEntryPointOp.getInterface()[static_cast<unsigned>(operandInterfaceId)])
-                    .getValue()) {
-                globalVarOp.setBinding(bindingId);
-                // TODO: DescriptorSet values to be handled correctly, currently they are set to 0
-                globalVarOp.setDescriptorSet(0);
-                return;
-            }
-        }
-    }
-}
-
 class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
   public:
     SerializeVGFPass() : SerializeVGFPass(std::make_shared<VGFBuilder>(), "binary.vgf", {}) {}
@@ -505,19 +477,6 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
                 return segmentWalkResult;
             });
         }
-
-        // Resolve Bindings and DescriptorSets in SPIR-V Modules
-        // TODO: This can perhaps be done in a better way
-        sequenceOp.walk([&](vgf::SegmentOp segmentOp) {
-            if (segmentOp.getSegmentType() != vgf::SegmentTypeEnum::GRAPH) {
-                return;
-            }
-            segmentOp.walk([&](spirv::GraphARMOp opGraph) {
-                for (const auto &[operand, bindingSlotRef] : mapOperandsAndBindingRef) {
-                    setGlobalVarOpBindingAndDescriptorSet(opGraph, operand, bindingSlotRef->reference);
-                }
-            });
-        });
 
         uint32_t computeSegmentId = 0;
         uint32_t graphSegmentId = 0;

--- a/src/include/passes.td
+++ b/src/include/passes.td
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2022-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2022-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
@@ -19,6 +19,15 @@ def SerializeVGFPass : Pass<"serialize-vgf", "mlir::vgf::SequenceOp"> {
 def VGFConstantsPass : Pass<"vgf-constants", "mlir::ModuleOp"> {
   let summary = "Serialize TOSA Constants to VGF";
   let description = [{Serialize TOSA MLIR constants to VGF.}];
+}
+
+def AssignGraphARMInterfaceVarABIPass : Pass<"assign-grapharm-interface-var-abi", "mlir::vgf::SequenceOp"> {
+  let summary = "Assign GraphARM ABI carrier attrs to graph segment signatures";
+  let description = [{
+    Computes the sequence-wide binding numbering currently used by VGF serialization
+    and annotates graph segment func.func arguments/results with
+    spv.grapharm.interface_var_abi so tosa-to-spirv can preserve the final ABI.
+  }];
 }
 
 def TosaShapedVerificationPass : Pass<"tosa-shape-verif", "func::FuncOp"> {

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2025-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
@@ -16,6 +16,7 @@ int main(int argc, char **argv) {
     registry.insert<func::FuncDialect, tosa::TosaDialect, spirv::SPIRVDialect, vgf::VGFDialect>();
 
     registerCheckConstantSparsityPass();
+    registerAssignGraphARMInterfaceVarABIPass();
     registerDenseResourceInlinerPass();
     registerModelPartitionMarkingPass();
     registerSignlessIntegerMarkingPass();


### PR DESCRIPTION
Add a dedicated `vgf.sequence` pass to compute the sequence-wide binding layout for graph segments and attach
`spv.grapharm.interface_var_abi` to graph `func.func` arguments/results before `tosa-to-spirv` runs.

This moves GraphARM binding assignment to the MLIR level and removes the late rewrite in `serialize_vgf.cpp` that patched lowered SPIR-V globals just before VGF serialization.

The new flow is:
- assign GraphARM ABI carrier attrs after partitioning
- preserve them in `tosa-to-spirv`
- lower them into SPIR-V globals via `spirv-lower-abi-attrs`
- serialize VGF without mutating SPIR-V modules
