### PR TITLE
Keep non-shader TOSA custom ops in graph partitions

### DIFF
--- a/src/conversion/model_partition_marking.cpp
+++ b/src/conversion/model_partition_marking.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
+#include "include/custom_op_domains.hpp"
 #include "include/passes.hpp"
 
 #include <algorithm>
@@ -38,7 +39,8 @@ class ModelPartitionMarkingPass : public impl::ModelPartitionMarkingPassBase<Mod
             op->setAttr("graph_partition_leaf_node", BoolAttr::get(op->getContext(), false));
 
             int64_t partitionId{-1};
-            if (llvm::isa<mlir::tosa::CustomOp>(op)) {
+            if (auto customOp = llvm::dyn_cast<mlir::tosa::CustomOp>(op);
+                customOp && isVulkanCustomShaderOp(customOp)) {
                 partitionId = highestPartitionId + 1;
                 op->setAttr("graph_partition_leaf_node", BoolAttr::get(op->getContext(), true));
                 for (auto operand : op->getOperands()) {
@@ -52,7 +54,8 @@ class ModelPartitionMarkingPass : public impl::ModelPartitionMarkingPassBase<Mod
                 for (auto operand : op->getOperands()) {
                     if (Operation *input = operand.getDefiningOp()) {
                         int64_t parentPartitionId = input->getAttrOfType<IntegerAttr>("graph_partition_id").getInt();
-                        if (llvm::isa<mlir::tosa::CustomOp>(input)) {
+                        if (auto parentCustomOp = llvm::dyn_cast<mlir::tosa::CustomOp>(input);
+                            parentCustomOp && isVulkanCustomShaderOp(parentCustomOp)) {
                             parentPartitionId = std::max(highestPartitionId, parentPartitionId + 1);
                         }
                         partitionId = std::max(partitionId, parentPartitionId);

--- a/src/conversion/model_partitioning.cpp
+++ b/src/conversion/model_partitioning.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
+#include "include/custom_op_domains.hpp"
 #include "include/passes.hpp"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -55,6 +56,10 @@ struct TosaCustomOpRewriter : public OpConversionPattern<tosa::CustomOp> {
 
     LogicalResult matchAndRewrite(tosa::CustomOp customOp, OpAdaptor adaptor,
                                   ConversionPatternRewriter &rewriter) const override {
+        if (!isVulkanCustomShaderOp(customOp)) {
+            return failure();
+        }
+
         json map;
         try {
             map = json::parse(adaptor.getImplementationAttrs().str());
@@ -402,7 +407,8 @@ class ModelPartitioningPass : public impl::ModelPartitioningPassBase<ModelPartit
                 const FunctionType segmentFunctionType =
                     builder.getFunctionType(ValueRange(inputs).getTypes(), ValueRange(results).getTypes());
 
-                bool isComputeSegment = partitionOps.size() == 1 && llvm::isa<tosa::CustomOp>(partitionOps[0]);
+                bool isComputeSegment = partitionOps.size() == 1 && llvm::isa<tosa::CustomOp>(partitionOps[0]) &&
+                                        isVulkanCustomShaderOp(llvm::cast<tosa::CustomOp>(partitionOps[0]));
                 const auto segmentType = isComputeSegment ? vgf::SegmentTypeEnum::COMPUTE : vgf::SegmentTypeEnum::GRAPH;
 
                 auto segmentOp = vgf::SegmentOp::create(builder, funcOp.getLoc(), segmentName, segmentType,
@@ -479,7 +485,7 @@ class ModelPartitioningPass : public impl::ModelPartitioningPassBase<ModelPartit
             [](func::FuncOp op) { return !llvm::isa<ModuleOp>(op->getParentOp()); });
         target.addDynamicallyLegalOp<func::ReturnOp>(
             [](func::ReturnOp op) { return !llvm::isa<ModuleOp>(op->getParentOp()->getParentOp()); });
-        target.addIllegalOp<tosa::CustomOp>();
+        target.addDynamicallyLegalOp<tosa::CustomOp>([](tosa::CustomOp op) { return !isVulkanCustomShaderOp(op); });
         target.addLegalDialect<vgf::VGFDialect, func::FuncDialect>();
         RewritePatternSet patterns(context);
         patterns.add<FuncOpRewriter, ReturnOpRewriter>(context);

--- a/src/include/custom_op_domains.hpp
+++ b/src/include/custom_op_domains.hpp
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+#pragma once
+
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace mlir::model_converter_passes {
+
+constexpr llvm::StringLiteral vulkanCustomShaderDomainName = "com.arm.VulkanCustomShader";
+
+inline bool isVulkanCustomShaderOp(tosa::CustomOp op) { return op.getDomainName() == vulkanCustomShaderDomainName; }
+
+} // namespace mlir::model_converter_passes


### PR DESCRIPTION
Only treat TOSA custom ops from the com.arm.VulkanCustomShader domain as Vulkan custom shader operations. These ops are split into compute segments and lowered to shader placeholders as before.

Leave all other tosa.custom ops in graph partitions.

Add a shared custom-op domain helper


Change-Id: I5ec33b5169f07d240493691fd0d201cc21bcd16d