### PR TITLE
Alias VGF resources for descriptor type changes

### DIFF
--- a/src/conversion/serialize_vgf.cpp
+++ b/src/conversion/serialize_vgf.cpp
@@ -169,11 +169,25 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
 
         DenseMap<Value, std::shared_ptr<BindingSlotRef>> mapOperandsAndBindingRef;
         DenseMap<Value, std::shared_ptr<ResourceRef>> mapOperandsAndResourceRef;
+        DenseMap<Value, uint32_t> mapOperandsAndBindingIndex;
+        DenseMap<Value, DescriptorType> mapOperandsAndDescriptorType;
+        DenseMap<Value, AliasGroupId> mapOperandsAndAliasGroupId;
+        DenseMap<Value, std::map<uint32_t, std::shared_ptr<ResourceRef>>> mapOperandsAndAliasedResourceRef;
         DenseMap<Value, std::map<uint32_t, BindingSlotRef>> mapOperandsAndDescriptorBindingRef;
         std::map<SegmentId, std::vector<BindingSlotRef>> mapSegmentInputBindings = {};
         std::map<SegmentId, std::vector<BindingSlotRef>> mapSegmentOutputBindings = {};
         std::map<SegmentId, std::map<uint32_t, std::vector<BindingSlotRef>>> mapSegmentDescriptorSetBindings = {};
         std::map<SegmentId, std::map<uint32_t, std::set<uint32_t>>> mapSegmentDescriptorSetBindingRefs = {};
+        AliasGroupId nextAliasGroupId = 0;
+
+        auto rememberOperandResource = [&](Value operand, DescriptorType descriptorType, uint32_t bindingIndex,
+                                           const std::shared_ptr<ResourceRef> &resourceRef,
+                                           const std::shared_ptr<BindingSlotRef> &bindingSlotRef) {
+            mapOperandsAndResourceRef[operand] = resourceRef;
+            mapOperandsAndBindingRef[operand] = bindingSlotRef;
+            mapOperandsAndBindingIndex[operand] = bindingIndex;
+            mapOperandsAndDescriptorType[operand] = descriptorType;
+        };
 
         auto addBindingToDescriptorSet = [&](const SegmentId segmentId, const int64_t descriptorSet,
                                              const BindingSlotRef bindingSlotRef) {
@@ -198,6 +212,59 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
             return descriptorBindingIt->second;
         };
 
+        auto getOrCreateAliasGroupId = [&](Value operand) -> AliasGroupId {
+            auto aliasGroupIt = mapOperandsAndAliasGroupId.find(operand);
+            if (aliasGroupIt == mapOperandsAndAliasGroupId.end()) {
+                assert(nextAliasGroupId != INVALID_ALIAS_GROUP_ID && "exhausted alias group ids");
+                auto resourceIt = mapOperandsAndResourceRef.find(operand);
+                assert(resourceIt != mapOperandsAndResourceRef.end());
+                const AliasGroupId aliasGroupId = nextAliasGroupId++;
+                _VGFBuilder->getEncoder()->SetAliasGroup(*(resourceIt->second), aliasGroupId);
+                aliasGroupIt = mapOperandsAndAliasGroupId.insert({operand, aliasGroupId}).first;
+            }
+            return aliasGroupIt->second;
+        };
+
+        auto getOrCreateAliasedResource = [&](Value operand, ResourceCategory category, DescriptorType descriptorType,
+                                              FormatType vkFormat,
+                                              const ShapedType type) -> std::shared_ptr<ResourceRef> {
+            auto &aliasedResources = mapOperandsAndAliasedResourceRef[operand];
+            const auto aliasKey = static_cast<uint32_t>(descriptorType);
+            auto aliasIt = aliasedResources.find(aliasKey);
+            if (aliasIt == aliasedResources.end()) {
+                const AliasGroupId aliasGroupId = getOrCreateAliasGroupId(operand);
+                switch (category) {
+                case ResourceCategory::INPUT:
+                    aliasIt = aliasedResources
+                                  .emplace(aliasKey,
+                                           std::make_shared<ResourceRef>(_VGFBuilder->getEncoder()->AddInputResource(
+                                               descriptorType, vkFormat, type.getShape(), {}, aliasGroupId)))
+                                  .first;
+                    break;
+                case ResourceCategory::OUTPUT:
+                    aliasIt = aliasedResources
+                                  .emplace(aliasKey,
+                                           std::make_shared<ResourceRef>(_VGFBuilder->getEncoder()->AddOutputResource(
+                                               descriptorType, vkFormat, type.getShape(), {}, aliasGroupId)))
+                                  .first;
+                    break;
+                case ResourceCategory::INTERMEDIATE:
+                    aliasIt =
+                        aliasedResources
+                            .emplace(aliasKey,
+                                     std::make_shared<ResourceRef>(_VGFBuilder->getEncoder()->AddIntermediateResource(
+                                         descriptorType, vkFormat, type.getShape(), {}, aliasGroupId)))
+                            .first;
+                    break;
+                case ResourceCategory::CONSTANT:
+                    assert(false && "aliased VGF resources must not be constants");
+                    return nullptr;
+                }
+            }
+            assert(aliasIt != aliasedResources.end() && "failed to create aliased VGF resource");
+            return aliasIt->second;
+        };
+
         // First: Resolve sequence input resources' bindings
         std::vector<BindingSlotRef> sequenceInputBindings = {};
         for (auto operand : sequenceOp.getArguments()) {
@@ -217,14 +284,16 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
                                        shaderPlaceholderOp.getInputDescriptorSets(), runSegmentOp->getOperands())) {
                             if (input == operand &&
                                 mapOperandsAndBindingRef.find(input) == mapOperandsAndBindingRef.end()) {
+                                const auto descriptorType =
+                                    NameToDescriptorType(llvm::cast<StringAttr>(inputDescriptorType).str());
                                 const ShapedType type = llvm::dyn_cast<ShapedType>(input.getType());
+                                const auto bindingIndex = operand.getArgNumber();
                                 const auto samplerConfigAttr =
                                     getSamplerConfig(shaderPlaceholderOp.getInputSamplerConfigsAttr(), ioIndex);
                                 auto resourceRef =
                                     std::make_shared<ResourceRef>(_VGFBuilder->getEncoder()->AddInputResource(
-                                        NameToDescriptorType(llvm::cast<StringAttr>(inputDescriptorType).str()),
-                                        NameToFormatType(llvm::cast<StringAttr>(inputVkFormat).str()), type.getShape(),
-                                        {}));
+                                        descriptorType, NameToFormatType(llvm::cast<StringAttr>(inputVkFormat).str()),
+                                        type.getShape(), {}));
 
                                 if (samplerConfigAttr && !samplerConfigAttr.empty()) {
                                     const auto samplerConfig = getSamplerConfigValues(
@@ -236,10 +305,10 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
                                 }
 
                                 auto bindingSlotRef = std::make_shared<BindingSlotRef>(
-                                    _VGFBuilder->getEncoder()->AddBindingSlot(operand.getArgNumber(), *resourceRef));
+                                    _VGFBuilder->getEncoder()->AddBindingSlot(bindingIndex, *resourceRef));
 
-                                mapOperandsAndResourceRef[input] = resourceRef;
-                                mapOperandsAndBindingRef[input] = bindingSlotRef;
+                                rememberOperandResource(input, descriptorType, bindingIndex, resourceRef,
+                                                        bindingSlotRef);
                                 sequenceInputBindings.push_back(*bindingSlotRef);
                                 mapSegmentInputBindings[segmentId].push_back(*bindingSlotRef);
                                 addBindingToDescriptorSet(
@@ -259,6 +328,7 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
                                     mapOperandsAndBindingRef.find(input) == mapOperandsAndBindingRef.end()) {
                                     VGFBuilder::VkFormat vkFormat;
                                     const ShapedType type = llvm::dyn_cast<ShapedType>(input.getType());
+                                    const auto bindingIndex = operand.getArgNumber();
 
                                     if (_VGFBuilder
                                             ->mlirTypeToVkFormat(
@@ -278,10 +348,10 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
                                         {});
 
                                     auto bindingSlotRef = std::make_shared<BindingSlotRef>(
-                                        _VGFBuilder->getEncoder()->AddBindingSlot(operand.getArgNumber(), resourceRef));
+                                        _VGFBuilder->getEncoder()->AddBindingSlot(bindingIndex, resourceRef));
 
-                                    mapOperandsAndResourceRef[input] = std::make_shared<ResourceRef>(resourceRef);
-                                    mapOperandsAndBindingRef[input] = bindingSlotRef;
+                                    rememberOperandResource(input, DESCRIPTOR_TYPE_TENSOR_ARM, bindingIndex,
+                                                            std::make_shared<ResourceRef>(resourceRef), bindingSlotRef);
                                     sequenceInputBindings.push_back(*bindingSlotRef);
                                     mapSegmentInputBindings[segmentId].push_back(*bindingSlotRef);
                                 }
@@ -323,17 +393,19 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
                                    shaderPlaceholderOp.getInputDescriptorSets(), runSegmentOp->getOperands())) {
                         if (!isSequenceInputOperand(input)) {
                             auto it = mapOperandsAndBindingRef.find(input);
+                            const auto descriptorType =
+                                NameToDescriptorType(llvm::cast<StringAttr>(inputDescriptorType).str());
                             if (it == mapOperandsAndBindingRef.end()) {
                                 // TODO: Revisit the need for conversion to ShapedType
                                 const ShapedType type = convertShapedType(input.getType());
+                                const auto bindingIndex = bindingId++;
                                 const auto samplerConfigAttr =
                                     getSamplerConfig(shaderPlaceholderOp.getInputSamplerConfigsAttr(), ioIndex);
 
                                 auto resourceRef =
                                     std::make_shared<ResourceRef>(_VGFBuilder->getEncoder()->AddIntermediateResource(
-                                        NameToDescriptorType(llvm::cast<StringAttr>(inputDescriptorType).str()),
-                                        NameToFormatType(llvm::cast<StringAttr>(inputVkFormat).str()), type.getShape(),
-                                        {}));
+                                        descriptorType, NameToFormatType(llvm::cast<StringAttr>(inputVkFormat).str()),
+                                        type.getShape(), {}));
 
                                 if (samplerConfigAttr && !samplerConfigAttr.empty()) {
                                     const auto samplerConfig = getSamplerConfigValues(
@@ -345,19 +417,39 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
                                 }
 
                                 auto bindingSlotRef = std::make_shared<BindingSlotRef>(
-                                    _VGFBuilder->getEncoder()->AddBindingSlot(bindingId++, *resourceRef));
+                                    _VGFBuilder->getEncoder()->AddBindingSlot(bindingIndex, *resourceRef));
 
-                                mapOperandsAndResourceRef[input] = resourceRef;
-                                mapOperandsAndBindingRef[input] = bindingSlotRef;
+                                rememberOperandResource(input, descriptorType, bindingIndex, resourceRef,
+                                                        bindingSlotRef);
                                 mapSegmentInputBindings[segmentId].push_back(*bindingSlotRef);
                                 addBindingToDescriptorSet(
                                     segmentId, inputDescriptorSet,
                                     getDescriptorSetBinding(input, static_cast<uint32_t>(inputBinding)));
                             } else {
-                                mapSegmentInputBindings[segmentId].push_back(*(it->second));
-                                addBindingToDescriptorSet(
-                                    segmentId, inputDescriptorSet,
-                                    getDescriptorSetBinding(input, static_cast<uint32_t>(inputBinding)));
+                                auto descriptorTypeIt = mapOperandsAndDescriptorType.find(input);
+                                auto bindingIndexIt = mapOperandsAndBindingIndex.find(input);
+                                assert(descriptorTypeIt != mapOperandsAndDescriptorType.end());
+                                assert(bindingIndexIt != mapOperandsAndBindingIndex.end());
+                                if (descriptorTypeIt->second != descriptorType) {
+                                    // Reuse the same logical value binding, but expose the storage through a second
+                                    // MRT entry so runtimes can see the buffer-vs-tensor view change.
+                                    const ShapedType type = convertShapedType(input.getType());
+                                    auto aliasResourceRef = getOrCreateAliasedResource(
+                                        input, ResourceCategory::INTERMEDIATE, descriptorType,
+                                        NameToFormatType(llvm::cast<StringAttr>(inputVkFormat).str()), type);
+                                    auto aliasBindingSlotRef = _VGFBuilder->getEncoder()->AddBindingSlot(
+                                        bindingIndexIt->second, *aliasResourceRef);
+                                    mapSegmentInputBindings[segmentId].push_back(aliasBindingSlotRef);
+                                    addBindingToDescriptorSet(
+                                        segmentId, inputDescriptorSet,
+                                        _VGFBuilder->getEncoder()->AddBindingSlot(static_cast<uint32_t>(inputBinding),
+                                                                                  *aliasResourceRef));
+                                } else {
+                                    mapSegmentInputBindings[segmentId].push_back(*(it->second));
+                                    addBindingToDescriptorSet(
+                                        segmentId, inputDescriptorSet,
+                                        getDescriptorSetBinding(input, static_cast<uint32_t>(inputBinding)));
+                                }
                             }
                         }
                         ++ioIndex;
@@ -372,17 +464,19 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
                                    shaderPlaceholderOp.getOutputDescriptorSets(), runSegmentOp->getResults())) {
                         if (!isSequenceOutputOperand(result)) {
                             auto it = mapOperandsAndBindingRef.find(result);
+                            const auto descriptorType =
+                                NameToDescriptorType(llvm::cast<StringAttr>(outputDescriptorType).str());
                             if (it == mapOperandsAndBindingRef.end()) {
                                 // TODO: Revisit the need for conversion to ShapedType
                                 const ShapedType type = convertShapedType(result.getType());
+                                const auto bindingIndex = bindingId++;
                                 const auto samplerConfigAttr =
                                     getSamplerConfig(shaderPlaceholderOp.getOutputSamplerConfigsAttr(), ioIndex);
 
                                 auto resourceRef =
                                     std::make_shared<ResourceRef>(_VGFBuilder->getEncoder()->AddIntermediateResource(
-                                        NameToDescriptorType(llvm::cast<StringAttr>(outputDescriptorType).str()),
-                                        NameToFormatType(llvm::cast<StringAttr>(outputVkFormat).str()), type.getShape(),
-                                        {}));
+                                        descriptorType, NameToFormatType(llvm::cast<StringAttr>(outputVkFormat).str()),
+                                        type.getShape(), {}));
 
                                 if (samplerConfigAttr && !samplerConfigAttr.empty()) {
                                     const auto samplerConfig = getSamplerConfigValues(
@@ -394,10 +488,10 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
                                 }
 
                                 auto bindingSlotRef = std::make_shared<BindingSlotRef>(
-                                    _VGFBuilder->getEncoder()->AddBindingSlot(bindingId++, *resourceRef));
+                                    _VGFBuilder->getEncoder()->AddBindingSlot(bindingIndex, *resourceRef));
 
-                                mapOperandsAndResourceRef[result] = resourceRef;
-                                mapOperandsAndBindingRef[result] = bindingSlotRef;
+                                rememberOperandResource(result, descriptorType, bindingIndex, resourceRef,
+                                                        bindingSlotRef);
                                 mapSegmentOutputBindings[segmentId].push_back(*bindingSlotRef);
                                 addBindingToDescriptorSet(
                                     segmentId, outputDescriptorSet,
@@ -434,11 +528,12 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
                                         DESCRIPTOR_TYPE_TENSOR_ARM, static_cast<FormatType>(vkFormat), type.getShape(),
                                         {});
 
+                                    const auto bindingIndex = bindingId++;
                                     auto bindingSlotRef = std::make_shared<BindingSlotRef>(
-                                        _VGFBuilder->getEncoder()->AddBindingSlot(bindingId++, resourceRef));
+                                        _VGFBuilder->getEncoder()->AddBindingSlot(bindingIndex, resourceRef));
 
-                                    mapOperandsAndResourceRef[input] = std::make_shared<ResourceRef>(resourceRef);
-                                    mapOperandsAndBindingRef[input] = bindingSlotRef;
+                                    rememberOperandResource(input, DESCRIPTOR_TYPE_TENSOR_ARM, bindingIndex,
+                                                            std::make_shared<ResourceRef>(resourceRef), bindingSlotRef);
                                     mapSegmentInputBindings[segmentId].push_back(*bindingSlotRef);
                                 } else {
                                     mapSegmentInputBindings[segmentId].push_back(*(it->second));
@@ -465,11 +560,12 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
                                             DESCRIPTOR_TYPE_TENSOR_ARM, static_cast<FormatType>(vkFormat),
                                             type.getShape(), {}));
 
+                                    const auto bindingIndex = bindingId++;
                                     auto bindingSlotRef = std::make_shared<BindingSlotRef>(
-                                        _VGFBuilder->getEncoder()->AddBindingSlot(bindingId++, *resourceRef));
+                                        _VGFBuilder->getEncoder()->AddBindingSlot(bindingIndex, *resourceRef));
 
-                                    mapOperandsAndResourceRef[result] = resourceRef;
-                                    mapOperandsAndBindingRef[result] = bindingSlotRef;
+                                    rememberOperandResource(result, DESCRIPTOR_TYPE_TENSOR_ARM, bindingIndex,
+                                                            resourceRef, bindingSlotRef);
                                     mapSegmentOutputBindings[segmentId].push_back(*bindingSlotRef);
                                 } else {
                                     mapSegmentOutputBindings[segmentId].push_back(*(it->second));
@@ -508,15 +604,17 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
 
                             if (result == operand &&
                                 mapOperandsAndBindingRef.find(result) == mapOperandsAndBindingRef.end()) {
+                                const auto descriptorType =
+                                    NameToDescriptorType(llvm::cast<StringAttr>(outputDescriptorType).str());
                                 const ShapedType type = llvm::dyn_cast<ShapedType>(result.getType());
+                                const auto bindingIndex = bindingId++;
                                 const auto samplerConfigAttr =
                                     getSamplerConfig(shaderPlaceholderOp.getOutputSamplerConfigsAttr(), ioIndex);
 
                                 auto resourceRef =
                                     std::make_shared<ResourceRef>(_VGFBuilder->getEncoder()->AddOutputResource(
-                                        NameToDescriptorType(llvm::cast<StringAttr>(outputDescriptorType).str()),
-                                        NameToFormatType(llvm::cast<StringAttr>(outputVkFormat).str()), type.getShape(),
-                                        {}));
+                                        descriptorType, NameToFormatType(llvm::cast<StringAttr>(outputVkFormat).str()),
+                                        type.getShape(), {}));
 
                                 if (samplerConfigAttr && !samplerConfigAttr.empty()) {
                                     const auto samplerConfig = getSamplerConfigValues(
@@ -528,10 +626,10 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
                                 }
 
                                 auto bindingSlotRef = std::make_shared<BindingSlotRef>(
-                                    _VGFBuilder->getEncoder()->AddBindingSlot(bindingId++, *resourceRef));
+                                    _VGFBuilder->getEncoder()->AddBindingSlot(bindingIndex, *resourceRef));
 
-                                mapOperandsAndResourceRef[result] = resourceRef;
-                                mapOperandsAndBindingRef[result] = bindingSlotRef;
+                                rememberOperandResource(result, descriptorType, bindingIndex, resourceRef,
+                                                        bindingSlotRef);
                                 sequenceOutputBindings.push_back(*bindingSlotRef);
                                 mapSegmentOutputBindings[segmentId].push_back(*bindingSlotRef);
                                 addBindingToDescriptorSet(
@@ -569,11 +667,12 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
                                         DESCRIPTOR_TYPE_TENSOR_ARM, static_cast<FormatType>(vkFormat), type.getShape(),
                                         {});
 
+                                    const auto bindingIndex = bindingId++;
                                     auto bindingSlotRef = std::make_shared<BindingSlotRef>(
-                                        _VGFBuilder->getEncoder()->AddBindingSlot(bindingId++, resourceRef));
+                                        _VGFBuilder->getEncoder()->AddBindingSlot(bindingIndex, resourceRef));
 
-                                    mapOperandsAndResourceRef[result] = std::make_shared<ResourceRef>(resourceRef);
-                                    mapOperandsAndBindingRef[result] = bindingSlotRef;
+                                    rememberOperandResource(result, DESCRIPTOR_TYPE_TENSOR_ARM, bindingIndex,
+                                                            std::make_shared<ResourceRef>(resourceRef), bindingSlotRef);
                                     sequenceOutputBindings.push_back(*bindingSlotRef);
                                     mapSegmentOutputBindings[segmentId].push_back(*bindingSlotRef);
                                 }

--- a/test/test_model_converter_custom_v100.py
+++ b/test/test_model_converter_custom_v100.py
@@ -13,6 +13,8 @@ from vgf_decoder import VK_FORMAT_R32G32B32A32_SFLOAT
 
 VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER = 1
 VK_DESCRIPTOR_TYPE_STORAGE_IMAGE = 3
+VK_DESCRIPTOR_TYPE_STORAGE_BUFFER = 7
+VK_DESCRIPTOR_TYPE_TENSOR_ARM = 1000460000
 
 SHADER_CASES = [
     {
@@ -80,11 +82,19 @@ def custom_shader_attrs(
     output_bindings,
     input_descriptor_sets=None,
     output_descriptor_sets=None,
+    input_vk_descriptor_types=None,
+    output_vk_descriptor_types=None,
     tensor_type="TENSOR",
     extra_attrs=None,
 ):
     input_descriptor_sets = input_descriptor_sets or [0] * len(input_bindings)
     output_descriptor_sets = output_descriptor_sets or [0] * len(output_bindings)
+    input_vk_descriptor_types = input_vk_descriptor_types or [
+        "VK_DESCRIPTOR_TYPE_TENSOR_ARM"
+    ] * len(input_bindings)
+    output_vk_descriptor_types = output_vk_descriptor_types or [
+        "VK_DESCRIPTOR_TYPE_TENSOR_ARM"
+    ] * len(output_bindings)
     implementation_attrs = {
         "entry_point": "main",
         "is_vkshader": True,
@@ -98,7 +108,7 @@ def custom_shader_attrs(
         ]
         implementation_attrs[f"input_{index}_type"] = tensor_type
         implementation_attrs[f"input_{index}_vkdescriptortype"] = (
-            "VK_DESCRIPTOR_TYPE_TENSOR_ARM"
+            input_vk_descriptor_types[index]
         )
         implementation_attrs[f"input_{index}_vkformat"] = vk_format
 
@@ -109,7 +119,7 @@ def custom_shader_attrs(
         ]
         implementation_attrs[f"output_{index}_type"] = tensor_type
         implementation_attrs[f"output_{index}_vkdescriptortype"] = (
-            "VK_DESCRIPTOR_TYPE_TENSOR_ARM"
+            output_vk_descriptor_types[index]
         )
         implementation_attrs[f"output_{index}_vkformat"] = vk_format
 
@@ -168,12 +178,16 @@ def custom_op(
     shader_case,
     vk_format,
     workgroup_sizes,
+    input_vk_descriptor_types=None,
+    output_vk_descriptor_types=None,
 ):
     implementation_attrs = custom_shader_attrs(
         vk_format=vk_format,
         workgroup_sizes=workgroup_sizes,
         input_bindings=[0, 1],
         output_bindings=[2],
+        input_vk_descriptor_types=input_vk_descriptor_types,
+        output_vk_descriptor_types=output_vk_descriptor_types,
         extra_attrs=shader_case["attrs"],
     )
     operands = ", ".join(operands)
@@ -250,6 +264,48 @@ def consecutive_custom_mlir(first_shader_case, second_shader_case):
         second_shader_case,
         "VK_FORMAT_R32_SFLOAT",
         [8, 8, 16],
+    )
+
+    return f"""
+module {{
+  func.func @main(%arg0: tensor<1x16x16x16xf32> {{tf_saved_model.index_path = ["input_0"]}}, %arg1: tensor<1x16x16x16xf32> {{tf_saved_model.index_path = ["input_1"]}}, %arg2: tensor<1x16x16x16xf32> {{tf_saved_model.index_path = ["input_2"]}}) -> (tensor<1x16x16x16xf32> {{tf_saved_model.index_path = ["output_0"]}}) attributes {{tf.entry_function = {{inputs = "input_0,input_1,input_2", outputs = "output_0"}}, tf_saved_model.exported_names = ["serving_default"]}} {{
+{first_custom}
+{second_custom}
+    return %1 : tensor<1x16x16x16xf32>
+  }}
+}}
+"""
+
+
+def descriptor_type_aliasing_mlir(
+    first_output_descriptor_type, second_input_descriptor_type
+):
+    tensor_type = "tensor<1x16x16x16xf32>"
+    shader_case = SHADER_CASES[0]
+    first_custom = custom_op(
+        "%0",
+        ["%arg0", "%arg1"],
+        [tensor_type, tensor_type],
+        tensor_type,
+        "test_descriptor_type_aliasing_shader_0",
+        shader_case,
+        "VK_FORMAT_R32_SFLOAT",
+        [16, 16, 16],
+        output_vk_descriptor_types=[first_output_descriptor_type],
+    )
+    second_custom = custom_op(
+        "%1",
+        ["%0", "%arg2"],
+        [tensor_type, tensor_type],
+        tensor_type,
+        "test_descriptor_type_aliasing_shader_1",
+        shader_case,
+        "VK_FORMAT_R32_SFLOAT",
+        [8, 8, 16],
+        input_vk_descriptor_types=[
+            second_input_descriptor_type,
+            "VK_DESCRIPTOR_TYPE_TENSOR_ARM",
+        ],
     )
 
     return f"""
@@ -409,6 +465,82 @@ def test_consecutive_custom_shader_modules(
         assert vgf.sequence.getSegmentType(1) == vgfpy.ModuleType.Compute
         assert vgf.sequence.getSegmentName(1) == "compute_segment_1"
         assert list(vgf.sequence.getSegmentDispatchShape(1)) == [8, 8, 16]
+
+
+def test_descriptor_type_change_creates_alias_group_for_intermediate(
+    model_converter_exe_path,
+):
+    with converted_mlir(
+        model_converter_exe_path,
+        descriptor_type_aliasing_mlir(
+            "VK_DESCRIPTOR_TYPE_TENSOR_ARM",
+            "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER",
+        ),
+    ) as vgf:
+        assert vgf.resources.size() == 6
+        assert vgf.resources.getCategory(3) == vgfpy.ResourceCategory.Intermediate
+        assert vgf.resources.getDescriptorType(3) == VK_DESCRIPTOR_TYPE_TENSOR_ARM
+        assert vgf.resources.getCategory(4) == vgfpy.ResourceCategory.Intermediate
+        assert vgf.resources.getDescriptorType(4) == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER
+
+        shared_alias_group = vgf.resources.getAliasGroupId(3)
+        assert shared_alias_group is not None
+        assert vgf.resources.getAliasGroupId(4) == shared_alias_group
+
+        assert vgf.resources.getAliasGroupId(0) is None
+        assert vgf.resources.getAliasGroupId(1) is None
+        assert vgf.resources.getAliasGroupId(2) is None
+        assert vgf.resources.getAliasGroupId(5) is None
+
+        first_outputs = vgf.sequence.getSegmentOutputBindingSlotsHandle(0)
+        assert vgf.sequence.getBindingsSize(first_outputs) == 1
+        assert vgf.sequence.getBindingSlotBinding(first_outputs, 0) == 3
+        assert vgf.sequence.getBindingSlotMrtIndex(first_outputs, 0) == 3
+
+        second_inputs = vgf.sequence.getSegmentInputBindingSlotsHandle(1)
+        assert vgf.sequence.getBindingsSize(second_inputs) == 2
+        second_input_bindings = sorted(
+            (
+                vgf.sequence.getBindingSlotBinding(second_inputs, binding_index),
+                vgf.sequence.getBindingSlotMrtIndex(second_inputs, binding_index),
+            )
+            for binding_index in range(vgf.sequence.getBindingsSize(second_inputs))
+        )
+        assert second_input_bindings == [(2, 2), (3, 4)]
+
+
+def test_descriptor_type_match_does_not_create_alias_group(
+    model_converter_exe_path,
+):
+    with converted_mlir(
+        model_converter_exe_path,
+        descriptor_type_aliasing_mlir(
+            "VK_DESCRIPTOR_TYPE_TENSOR_ARM",
+            "VK_DESCRIPTOR_TYPE_TENSOR_ARM",
+        ),
+    ) as vgf:
+        assert vgf.resources.size() == 5
+        assert vgf.resources.getCategory(3) == vgfpy.ResourceCategory.Intermediate
+        assert vgf.resources.getDescriptorType(3) == VK_DESCRIPTOR_TYPE_TENSOR_ARM
+
+        for resource_index in range(vgf.resources.size()):
+            assert vgf.resources.getAliasGroupId(resource_index) is None
+
+        first_outputs = vgf.sequence.getSegmentOutputBindingSlotsHandle(0)
+        assert vgf.sequence.getBindingsSize(first_outputs) == 1
+        assert vgf.sequence.getBindingSlotBinding(first_outputs, 0) == 3
+        assert vgf.sequence.getBindingSlotMrtIndex(first_outputs, 0) == 3
+
+        second_inputs = vgf.sequence.getSegmentInputBindingSlotsHandle(1)
+        assert vgf.sequence.getBindingsSize(second_inputs) == 2
+        second_input_bindings = sorted(
+            (
+                vgf.sequence.getBindingSlotBinding(second_inputs, binding_index),
+                vgf.sequence.getBindingSlotMrtIndex(second_inputs, binding_index),
+            )
+            for binding_index in range(vgf.sequence.getBindingsSize(second_inputs))
+        )
+        assert second_input_bindings == [(2, 2), (3, 3)]
 
 
 def test_custom_graph_custom_segments(model_converter_exe_path):


### PR DESCRIPTION
Track each operand's binding index and descriptor type during VGF serialization so reused values keep a stable logical binding. When a later shader placeholder needs the same value through a different descriptor type, create an aliased resource and descriptor-set binding for that view instead of reusing the original resource directly.

Change-Id: I53349427b5c324c719f476beef75171c6e983a65