### PR TITLE
Keep zero-input ops out of Vulkan compute partitions

### DIFF
--- a/src/conversion/model_partition_marking.cpp
+++ b/src/conversion/model_partition_marking.cpp
@@ -13,13 +13,23 @@ namespace mlir::model_converter_passes {
 #include "passes.hpp.inc"
 namespace {
 
+enum class PartitionKind { Graph, Compute };
+
+int64_t assignStandaloneGraphPartition(const int64_t highestPartitionId, const PartitionKind highestPartitionKind) {
+    if (highestPartitionId < 0) {
+        return 0;
+    }
+    return highestPartitionKind == PartitionKind::Compute ? highestPartitionId + 1 : highestPartitionId;
+}
+
 class ModelPartitionMarkingPass : public impl::ModelPartitionMarkingPassBase<ModelPartitionMarkingPass> {
   public:
     void runOnOperation() override {
         mlir::ModuleOp moduleOp = getOperation();
         const Type tI32 = IntegerType::get(moduleOp.getContext(), 32);
         int64_t highestPartitionId{-1};
-        moduleOp.walk([&tI32, &highestPartitionId](Operation *op) {
+        PartitionKind highestPartitionKind = PartitionKind::Graph;
+        moduleOp.walk([&tI32, &highestPartitionId, &highestPartitionKind](Operation *op) {
             if (llvm::isa<mlir::ModuleOp>(op) || llvm::isa<mlir::func::FuncOp>(op)) {
                 return;
             }
@@ -38,9 +48,11 @@ class ModelPartitionMarkingPass : public impl::ModelPartitionMarkingPassBase<Mod
 
             op->setAttr("graph_partition_leaf_node", BoolAttr::get(op->getContext(), false));
 
+            PartitionKind partitionKind = PartitionKind::Graph;
             int64_t partitionId{-1};
             if (auto customOp = llvm::dyn_cast<mlir::tosa::CustomOp>(op);
                 customOp && isVulkanCustomShaderOp(customOp)) {
+                partitionKind = PartitionKind::Compute;
                 partitionId = highestPartitionId + 1;
                 op->setAttr("graph_partition_leaf_node", BoolAttr::get(op->getContext(), true));
                 for (auto operand : op->getOperands()) {
@@ -65,7 +77,10 @@ class ModelPartitionMarkingPass : public impl::ModelPartitionMarkingPassBase<Mod
                     }
                 }
                 if (partitionId < 0) {
-                    partitionId = std::max(highestPartitionId, int64_t(0));
+                    // Graph ops without any defining producer in the current sequence stay in a graph-owned
+                    // partition. If the most recent partition is compute, start a new graph partition so the
+                    // Vulkan custom segment remains single-op.
+                    partitionId = assignStandaloneGraphPartition(highestPartitionId, highestPartitionKind);
                 }
 
                 // set leaf node flags on the op inputs if needed
@@ -82,7 +97,12 @@ class ModelPartitionMarkingPass : public impl::ModelPartitionMarkingPassBase<Mod
                 }
             }
 
-            highestPartitionId = std::max(highestPartitionId, partitionId);
+            if (partitionId > highestPartitionId) {
+                highestPartitionId = partitionId;
+                highestPartitionKind = partitionKind;
+            } else if (partitionId == highestPartitionId && partitionKind == PartitionKind::Graph) {
+                highestPartitionKind = PartitionKind::Graph;
+            }
             op->setAttr("graph_partition_id", IntegerAttr::get(tI32, partitionId));
         });
     }

--- a/test/lit/model-partition-marking-vulkan-custom-trailing-graph-ops.mlir
+++ b/test/lit/model-partition-marking-vulkan-custom-trailing-graph-ops.mlir
@@ -1,0 +1,89 @@
+//
+// SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+
+// RUN: model-converter-opt --split-input-file --model-partition-marking %s | FileCheck %s
+
+// CHECK-LABEL: func.func @trailing_const
+func.func @trailing_const(%arg0: tensor<1x16x16x16xf32> {tf_saved_model.index_path = ["input_0"]}, %arg1: tensor<1x16x16x16xf32> {tf_saved_model.index_path = ["input_1"]}, %arg2: tensor<1x16x16x16xf32> {tf_saved_model.index_path = ["input_2"]}) -> (tensor<1x16x16x16xf32> {tf_saved_model.index_path = ["output_0"]}) attributes {tf.entry_function = {inputs = "input_0,input_1,input_2", outputs = "output_0"}, tf_saved_model.exported_names = ["serving_default"]} {
+  // CHECK: tosa.add
+  // CHECK-SAME: graph_partition_id = 0 : i32
+  // CHECK-SAME: graph_partition_leaf_node = true
+  %0 = tosa.add %arg0, %arg1 : (tensor<1x16x16x16xf32>, tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
+  // CHECK: tosa.custom
+  // CHECK-SAME: graph_partition_id = 1 : i32
+  // CHECK-SAME: graph_partition_leaf_node = true
+  %1 = tosa.custom %0, %arg2 {domain_name = "com.arm.VulkanCustomShader", implementation_attrs = "{\22entry_point\22:\22main\22,\22is_vkshader\22:true,\22workgroup_sizes\22:[16,16,16],\22input_0_binding\22:0,\22input_0_descriptorset\22:0,\22input_0_type\22:\22TENSOR\22,\22input_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22input_0_vkformat\22:\22VK_FORMAT_R32_SFLOAT\22,\22input_1_binding\22:1,\22input_1_descriptorset\22:0,\22input_1_type\22:\22TENSOR\22,\22input_1_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22input_1_vkformat\22:\22VK_FORMAT_R32_SFLOAT\22,\22output_0_binding\22:2,\22output_0_descriptorset\22:0,\22output_0_type\22:\22TENSOR\22,\22output_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22output_0_vkformat\22:\22VK_FORMAT_R32_SFLOAT\22}", operator_name = "test_trailing_const_shader"} : (tensor<1x16x16x16xf32>, tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
+  // CHECK: "tosa.const"
+  // CHECK-SAME: graph_partition_id = 2 : i32
+  // CHECK-SAME: graph_partition_leaf_node = false
+  %2 = "tosa.const"() {values = dense<1.000000e+00> : tensor<1x16x16x16xf32>} : () -> tensor<1x16x16x16xf32>
+  // CHECK: tosa.add
+  // CHECK-SAME: graph_partition_id = 2 : i32
+  // CHECK-SAME: graph_partition_leaf_node = true
+  %3 = tosa.add %1, %2 : (tensor<1x16x16x16xf32>, tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
+  return %3 : tensor<1x16x16x16xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @multiple_trailing_consts
+func.func @multiple_trailing_consts(%arg0: tensor<1x16x16x16xf32> {tf_saved_model.index_path = ["input_0"]}, %arg1: tensor<1x16x16x16xf32> {tf_saved_model.index_path = ["input_1"]}, %arg2: tensor<1x16x16x16xf32> {tf_saved_model.index_path = ["input_2"]}) -> (tensor<1x16x16x16xf32> {tf_saved_model.index_path = ["output_0"]}) attributes {tf.entry_function = {inputs = "input_0,input_1,input_2", outputs = "output_0"}, tf_saved_model.exported_names = ["serving_default"]} {
+  // CHECK: tosa.add
+  // CHECK-SAME: graph_partition_id = 0 : i32
+  // CHECK-SAME: graph_partition_leaf_node = true
+  %0 = tosa.add %arg0, %arg1 : (tensor<1x16x16x16xf32>, tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
+  // CHECK: tosa.custom
+  // CHECK-SAME: graph_partition_id = 1 : i32
+  // CHECK-SAME: graph_partition_leaf_node = true
+  %1 = tosa.custom %0, %arg2 {domain_name = "com.arm.VulkanCustomShader", implementation_attrs = "{\22entry_point\22:\22main\22,\22is_vkshader\22:true,\22workgroup_sizes\22:[16,16,16],\22input_0_binding\22:0,\22input_0_descriptorset\22:0,\22input_0_type\22:\22TENSOR\22,\22input_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22input_0_vkformat\22:\22VK_FORMAT_R32_SFLOAT\22,\22input_1_binding\22:1,\22input_1_descriptorset\22:0,\22input_1_type\22:\22TENSOR\22,\22input_1_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22input_1_vkformat\22:\22VK_FORMAT_R32_SFLOAT\22,\22output_0_binding\22:2,\22output_0_descriptorset\22:0,\22output_0_type\22:\22TENSOR\22,\22output_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22output_0_vkformat\22:\22VK_FORMAT_R32_SFLOAT\22}", operator_name = "test_trailing_const_shader"} : (tensor<1x16x16x16xf32>, tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
+  // CHECK: "tosa.const"
+  // CHECK-SAME: graph_partition_id = 2 : i32
+  // CHECK-SAME: graph_partition_leaf_node = false
+  %2 = "tosa.const"() {values = dense<1.000000e+00> : tensor<1x16x16x16xf32>} : () -> tensor<1x16x16x16xf32>
+  // CHECK: "tosa.const"
+  // CHECK-SAME: graph_partition_id = 2 : i32
+  // CHECK-SAME: graph_partition_leaf_node = false
+  %3 = "tosa.const"() {values = dense<2.000000e+00> : tensor<1x16x16x16xf32>} : () -> tensor<1x16x16x16xf32>
+  // CHECK: "tosa.const"
+  // CHECK-SAME: graph_partition_id = 2 : i32
+  // CHECK-SAME: graph_partition_leaf_node = false
+  %4 = "tosa.const"() {values = dense<3.000000e+00> : tensor<1x16x16x16xf32>} : () -> tensor<1x16x16x16xf32>
+  // CHECK: tosa.add
+  // CHECK-SAME: graph_partition_id = 2 : i32
+  // CHECK-SAME: graph_partition_leaf_node = false
+  %5 = tosa.add %1, %2 : (tensor<1x16x16x16xf32>, tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
+  // CHECK: tosa.add
+  // CHECK-SAME: graph_partition_id = 2 : i32
+  // CHECK-SAME: graph_partition_leaf_node = false
+  %6 = tosa.add %5, %3 : (tensor<1x16x16x16xf32>, tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
+  // CHECK: tosa.add
+  // CHECK-SAME: graph_partition_id = 2 : i32
+  // CHECK-SAME: graph_partition_leaf_node = true
+  %7 = tosa.add %6, %4 : (tensor<1x16x16x16xf32>, tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
+  return %7 : tensor<1x16x16x16xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @trailing_arg_only_graph_op
+func.func @trailing_arg_only_graph_op(%arg0: tensor<1x16x16x16xf32> {tf_saved_model.index_path = ["input_0"]}, %arg1: tensor<1x16x16x16xf32> {tf_saved_model.index_path = ["input_1"]}, %arg2: tensor<1x16x16x16xf32> {tf_saved_model.index_path = ["input_2"]}) -> (tensor<1x16x16x16xf32> {tf_saved_model.index_path = ["output_0"]}) attributes {tf.entry_function = {inputs = "input_0,input_1,input_2", outputs = "output_0"}, tf_saved_model.exported_names = ["serving_default"]} {
+  // CHECK: tosa.add
+  // CHECK-SAME: graph_partition_id = 0 : i32
+  // CHECK-SAME: graph_partition_leaf_node = true
+  %0 = tosa.add %arg0, %arg1 : (tensor<1x16x16x16xf32>, tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
+  // CHECK: tosa.custom
+  // CHECK-SAME: graph_partition_id = 1 : i32
+  // CHECK-SAME: graph_partition_leaf_node = true
+  %1 = tosa.custom %0, %arg2 {domain_name = "com.arm.VulkanCustomShader", implementation_attrs = "{\22entry_point\22:\22main\22,\22is_vkshader\22:true,\22workgroup_sizes\22:[16,16,16],\22input_0_binding\22:0,\22input_0_descriptorset\22:0,\22input_0_type\22:\22TENSOR\22,\22input_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22input_0_vkformat\22:\22VK_FORMAT_R32_SFLOAT\22,\22input_1_binding\22:1,\22input_1_descriptorset\22:0,\22input_1_type\22:\22TENSOR\22,\22input_1_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22input_1_vkformat\22:\22VK_FORMAT_R32_SFLOAT\22,\22output_0_binding\22:2,\22output_0_descriptorset\22:0,\22output_0_type\22:\22TENSOR\22,\22output_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22output_0_vkformat\22:\22VK_FORMAT_R32_SFLOAT\22}", operator_name = "test_trailing_arg_only_graph_shader"} : (tensor<1x16x16x16xf32>, tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
+  // CHECK: tosa.abs
+  // CHECK-SAME: graph_partition_id = 2 : i32
+  // CHECK-SAME: graph_partition_leaf_node = false
+  %2 = tosa.abs %arg0 : (tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
+  // CHECK: tosa.add
+  // CHECK-SAME: graph_partition_id = 2 : i32
+  // CHECK-SAME: graph_partition_leaf_node = true
+  %3 = tosa.add %1, %2 : (tensor<1x16x16x16xf32>, tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
+  return %3 : tensor<1x16x16x16xf32>
+}


### PR DESCRIPTION
Assign explicit graph ownership to standalone zero-input ops in the partitioning path instead of inheriting the current highest partition id. This keeps Vulkan tosa.custom segments as single-op compute partitions even when trailing tosa.const ops appear nearby in lexical order.

Add regression tests for single and multiple trailing zero-input ops

Change-Id: Ia20c01bcc805defcb26c112e0461bd93ceef0688