### PR TITLE
Fix operand-order dependent partition leaf marking

### DIFF
--- a/src/conversion/model_partition_marking.cpp
+++ b/src/conversion/model_partition_marking.cpp
@@ -61,19 +61,17 @@ class ModelPartitionMarkingPass : public impl::ModelPartitionMarkingPassBase<Mod
                     }
                 }
             } else {
-                bool setLeafFlags = false;
+                SmallVector<Operation *> inputs;
                 // compute the partition id for the current op
                 for (auto operand : op->getOperands()) {
                     if (Operation *input = operand.getDefiningOp()) {
+                        inputs.push_back(input);
                         int64_t parentPartitionId = input->getAttrOfType<IntegerAttr>("graph_partition_id").getInt();
                         if (auto parentCustomOp = llvm::dyn_cast<mlir::tosa::CustomOp>(input);
                             parentCustomOp && isVulkanCustomShaderOp(parentCustomOp)) {
                             parentPartitionId = std::max(highestPartitionId, parentPartitionId + 1);
                         }
                         partitionId = std::max(partitionId, parentPartitionId);
-                        if (parentPartitionId < partitionId) {
-                            setLeafFlags = true;
-                        }
                     }
                 }
                 if (partitionId < 0) {
@@ -83,16 +81,12 @@ class ModelPartitionMarkingPass : public impl::ModelPartitionMarkingPassBase<Mod
                     partitionId = assignStandaloneGraphPartition(highestPartitionId, highestPartitionKind);
                 }
 
-                // set leaf node flags on the op inputs if needed
-                if (setLeafFlags) {
-                    for (auto operand : op->getOperands()) {
-                        if (Operation *input = operand.getDefiningOp()) {
-                            int64_t parentPartitionId =
-                                input->getAttrOfType<IntegerAttr>("graph_partition_id").getInt();
-                            if (parentPartitionId < partitionId) {
-                                input->setAttr("graph_partition_leaf_node", BoolAttr::get(op->getContext(), true));
-                            }
-                        }
+                // Set leaf node flags after the current op's final partition is known. This keeps cross-partition
+                // operand detection independent of operand order.
+                for (Operation *input : inputs) {
+                    int64_t parentPartitionId = input->getAttrOfType<IntegerAttr>("graph_partition_id").getInt();
+                    if (parentPartitionId < partitionId) {
+                        input->setAttr("graph_partition_leaf_node", BoolAttr::get(op->getContext(), true));
                     }
                 }
             }

--- a/test/lit/model-partition-marking-vulkan-custom-trailing-graph-ops.mlir
+++ b/test/lit/model-partition-marking-vulkan-custom-trailing-graph-ops.mlir
@@ -87,3 +87,26 @@ func.func @trailing_arg_only_graph_op(%arg0: tensor<1x16x16x16xf32> {tf_saved_mo
   %3 = tosa.add %1, %2 : (tensor<1x16x16x16xf32>, tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
   return %3 : tensor<1x16x16x16xf32>
 }
+
+// -----
+
+// CHECK-LABEL: func.func @cross_partition_input_before_raising_operand
+func.func @cross_partition_input_before_raising_operand(%arg0: tensor<1x16x16x16xf32> {tf_saved_model.index_path = ["input_0"]}, %arg1: tensor<1x16x16x16xf32> {tf_saved_model.index_path = ["input_1"]}) -> (tensor<1x16x16x16xf32> {tf_saved_model.index_path = ["output_0"]}) attributes {tf.entry_function = {inputs = "input_0,input_1", outputs = "output_0"}, tf_saved_model.exported_names = ["serving_default"]} {
+  // CHECK: tosa.abs
+  // CHECK-SAME: graph_partition_id = 0 : i32
+  // CHECK-SAME: graph_partition_leaf_node = true
+  %0 = tosa.abs %arg0 : (tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
+  // CHECK: tosa.custom
+  // CHECK-SAME: graph_partition_id = 1 : i32
+  // CHECK-SAME: graph_partition_leaf_node = true
+  %1 = tosa.custom %arg1, %arg1 {domain_name = "com.arm.VulkanCustomShader", implementation_attrs = "{\22entry_point\22:\22main\22,\22is_vkshader\22:true,\22workgroup_sizes\22:[16,16,16],\22input_0_binding\22:0,\22input_0_descriptorset\22:0,\22input_0_type\22:\22TENSOR\22,\22input_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22input_0_vkformat\22:\22VK_FORMAT_R32_SFLOAT\22,\22input_1_binding\22:1,\22input_1_descriptorset\22:0,\22input_1_type\22:\22TENSOR\22,\22input_1_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22input_1_vkformat\22:\22VK_FORMAT_R32_SFLOAT\22,\22output_0_binding\22:2,\22output_0_descriptorset\22:0,\22output_0_type\22:\22TENSOR\22,\22output_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22output_0_vkformat\22:\22VK_FORMAT_R32_SFLOAT\22}", operator_name = "test_late_partition_raise_shader"} : (tensor<1x16x16x16xf32>, tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
+  // CHECK: tosa.abs
+  // CHECK-SAME: graph_partition_id = 2 : i32
+  // CHECK-SAME: graph_partition_leaf_node = false
+  %2 = tosa.abs %1 : (tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
+  // CHECK: tosa.add
+  // CHECK-SAME: graph_partition_id = 2 : i32
+  // CHECK-SAME: graph_partition_leaf_node = true
+  %3 = tosa.add %0, %2 : (tensor<1x16x16x16xf32>, tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
+  return %3 : tensor<1x16x16x16xf32>
+}


### PR DESCRIPTION
Compute each graph op's final partition before marking cross-partition operands as leaf nodes. Previously, an operand from an earlier partition could be skipped if it appeared before another operand that raised the consumer into a later partition, leaving the generated run_segment with a dangling reference after old TOSA ops were erased.

Change-Id: Ib8ebb10f79de31c6fe27a00cc33f342e60e88a33