### PR TITLE
Make compute resource planning explicit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ set(CONVERTER_PASS_LIB_SOURCES
     "src/conversion/dense_resource_inliner.cpp"
     "src/conversion/model_partition_marking.cpp"
     "src/conversion/model_partitioning.cpp"
+    "src/conversion/resource_planner.cpp"
     "src/conversion/serialize_vgf.cpp"
     "src/conversion/signless_integer_marking.cpp"
     "src/conversion/type_narrowing.cpp"

--- a/src/conversion/resource_planner.cpp
+++ b/src/conversion/resource_planner.cpp
@@ -1,0 +1,734 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+#include "conversion/resource_planner.hpp"
+
+#include "utils.hpp"
+
+#define VGFLIB_VK_HELPERS
+#include "vgf/vulkan_helpers.generated.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <iterator>
+
+namespace mlir::model_converter_passes::detail {
+namespace {
+
+// As defined in vulkan_core.h
+constexpr DescriptorType DESCRIPTOR_TYPE_TENSOR_ARM = 1000460000;
+constexpr StringRef UNSIGNED_INPUT_OUTPUT_ATTR = "mlsdk.unsigned_input_output";
+constexpr StringRef MIN_FILTER_ATTR = "min_filter";
+constexpr StringRef MAG_FILTER_ATTR = "mag_filter";
+constexpr StringRef ADDRESS_MODE_U_ATTR = "address_mode_u";
+constexpr StringRef ADDRESS_MODE_V_ATTR = "address_mode_v";
+constexpr StringRef BORDER_COLOR_ATTR = "border_color";
+
+template <typename ParseFn> uint32_t parseSamplerEnumValue(const StringRef name, ParseFn &&parseFn) {
+    if (name.empty()) {
+        return UNSET_SAMPLER_VALUE;
+    }
+    const auto value = parseFn(name.str());
+    return value < 0 ? UNSET_SAMPLER_VALUE : static_cast<uint32_t>(value);
+}
+
+uint32_t parseSamplerFilter(const StringRef name) { return parseSamplerEnumValue(name, NameToFilterType); }
+
+uint32_t parseSamplerAddressMode(const StringRef name) {
+    return parseSamplerEnumValue(name, NameToSamplerAddressModeType);
+}
+
+uint32_t parseSamplerBorderColor(const StringRef name) { return parseSamplerEnumValue(name, NameToBorderColorType); }
+
+DictionaryAttr getSamplerConfig(ArrayAttr samplerConfigsAttr, size_t index) {
+    if (!samplerConfigsAttr || index >= samplerConfigsAttr.size()) {
+        return nullptr;
+    }
+    return llvm::dyn_cast<DictionaryAttr>(samplerConfigsAttr[static_cast<unsigned>(index)]);
+}
+
+uint32_t getSamplerValue(DictionaryAttr samplerConfigAttr, StringRef key,
+                         const std::function<uint32_t(StringRef)> &parseFn) {
+    if (!samplerConfigAttr) {
+        return UNSET_SAMPLER_VALUE;
+    }
+    auto valueAttr = samplerConfigAttr.getAs<StringAttr>(key);
+    if (!valueAttr) {
+        return UNSET_SAMPLER_VALUE;
+    }
+    return parseFn(valueAttr.getValue());
+}
+
+std::optional<SamplerConfigValues> getOptionalSamplerConfigValues(ArrayAttr samplerConfigsAttr, size_t index) {
+    const auto samplerConfigAttr = getSamplerConfig(samplerConfigsAttr, index);
+    if (!samplerConfigAttr || samplerConfigAttr.empty()) {
+        return std::nullopt;
+    }
+
+    SamplerConfigValues samplerConfig;
+    samplerConfig.minFilter = getSamplerValue(samplerConfigAttr, MIN_FILTER_ATTR, parseSamplerFilter);
+    samplerConfig.magFilter = getSamplerValue(samplerConfigAttr, MAG_FILTER_ATTR, parseSamplerFilter);
+    samplerConfig.addressModeU = getSamplerValue(samplerConfigAttr, ADDRESS_MODE_U_ATTR, parseSamplerAddressMode);
+    samplerConfig.addressModeV = getSamplerValue(samplerConfigAttr, ADDRESS_MODE_V_ATTR, parseSamplerAddressMode);
+    samplerConfig.borderColor = getSamplerValue(samplerConfigAttr, BORDER_COLOR_ATTR, parseSamplerBorderColor);
+    return samplerConfig;
+}
+
+const std::vector<BindingSlotRef> &
+getSegmentBindings(const std::map<SegmentId, std::vector<BindingSlotRef>> &bindingsBySegment, SegmentId segmentId) {
+    static const std::vector<BindingSlotRef> emptyBindings = {};
+    auto bindingsIt = bindingsBySegment.find(segmentId);
+    if (bindingsIt == bindingsBySegment.end()) {
+        return emptyBindings;
+    }
+    return bindingsIt->second;
+}
+
+} // namespace
+
+ResourcePlanner::ResourcePlanner(vgf::SequenceOp &sequenceOp)
+    : _sequenceOp(sequenceOp), _sequenceOutputOp(sequenceOp.front().getTerminator()),
+      _bindingId(sequenceOp.getNumArguments()) {
+    _resourcePlan.sequenceInputValues.assign(sequenceOp.getArguments().begin(), sequenceOp.getArguments().end());
+    _resourcePlan.sequenceOutputValues.assign(_sequenceOutputOp->getOperands().begin(),
+                                              _sequenceOutputOp->getOperands().end());
+    for (const auto &[outputIndex, outputValue] : llvm::enumerate(_sequenceOutputOp->getOperands())) {
+        _sequenceOutputIndices[outputValue] = static_cast<uint32_t>(outputIndex);
+    }
+}
+
+LogicalResult ResourcePlanner::buildPlan() {
+    if (collectSequenceInputs().failed() || collectIntermediates().failed() || collectSequenceOutputs().failed()) {
+        return failure();
+    }
+
+    finalizePlannedValues();
+    return success();
+}
+
+const ResourcePlan &ResourcePlanner::getPlan() const { return _resourcePlan; }
+
+bool ResourcePlanner::isSequenceInputOperand(Value operand) const {
+    return std::any_of(_sequenceOp.getArguments().begin(), _sequenceOp.getArguments().end(),
+                       [&](const Value sequenceOpArgument) { return sequenceOpArgument == operand; });
+}
+
+bool ResourcePlanner::isSequenceOutputOperand(Value operand) const {
+    return _sequenceOutputIndices.find(operand) != _sequenceOutputIndices.end();
+}
+
+bool ResourcePlanner::getSequenceInputUnsigned(uint32_t inputIndex) const {
+    if (auto unsignedAttr = _sequenceOp.getArgAttrOfType<BoolAttr>(inputIndex, UNSIGNED_INPUT_OUTPUT_ATTR)) {
+        return unsignedAttr.getValue();
+    }
+    return false;
+}
+
+bool ResourcePlanner::getSequenceOutputUnsigned(uint32_t outputIndex) const {
+    if (auto unsignedAttr = _sequenceOp.getResultAttrOfType<BoolAttr>(outputIndex, UNSIGNED_INPUT_OUTPUT_ATTR)) {
+        return unsignedAttr.getValue();
+    }
+    return false;
+}
+
+FailureOr<std::vector<int64_t>> ResourcePlanner::getValueShape(Value value) const {
+    const ShapedType type = (isSequenceInputOperand(value) || isSequenceOutputOperand(value))
+                                ? llvm::dyn_cast<ShapedType>(value.getType())
+                                : convertShapedType(value.getType());
+    if (!type) {
+        return _sequenceOp.emitError("expected shaped value when serializing VGF resources");
+    }
+    return std::vector<int64_t>(type.getShape().begin(), type.getShape().end());
+}
+
+LogicalResult ResourcePlanner::getGraphView(Value value, StringRef role, StringRef segmentName,
+                                            ResourceViewKey &view) const {
+    VGFBuilder::VkFormat vkFormat;
+    const ShapedType type = (isSequenceInputOperand(value) || isSequenceOutputOperand(value))
+                                ? llvm::dyn_cast<ShapedType>(value.getType())
+                                : convertShapedType(value.getType());
+    if (!type) {
+        return _sequenceOp.emitError("expected shaped value for ") << role << " in segment " << segmentName;
+    }
+
+    bool isUnsigned = false;
+    if (isSequenceInputOperand(value)) {
+        isUnsigned = getSequenceInputUnsigned(llvm::cast<BlockArgument>(value).getArgNumber());
+    } else if (isSequenceOutputOperand(value)) {
+        auto outputIndexIt = _sequenceOutputIndices.find(value);
+        if (outputIndexIt == _sequenceOutputIndices.end()) {
+            return _sequenceOp.emitError("failed to resolve sequence output index for ")
+                   << role << " in segment " << segmentName;
+        }
+        isUnsigned = getSequenceOutputUnsigned(outputIndexIt->second);
+    }
+
+    if (VGFBuilder::mlirTypeToVkFormat(type.getElementType(), vkFormat, isUnsigned).failed()) {
+        return _sequenceOp.emitError("unsupported type for ") << role << " in segment " << segmentName;
+    }
+
+    view = {DESCRIPTOR_TYPE_TENSOR_ARM, static_cast<FormatType>(vkFormat)};
+    return success();
+}
+
+ResourceKey ResourcePlanner::makeResourceKey(ResourceCategory category, const ResourceViewKey &view,
+                                             std::optional<SamplerConfigValues> samplerConfig) {
+    return ResourceKey{category, view, samplerConfig};
+}
+
+FailureOr<PlannedValue *> ResourcePlanner::ensurePlannedValue(Value value, std::optional<uint32_t> bindingIndex) {
+    auto [it, inserted] = _resourcePlan.plannedValues.try_emplace(value);
+    auto &plan = it->second;
+    if (inserted) {
+        auto shape = getValueShape(value);
+        if (failed(shape)) {
+            _resourcePlan.plannedValues.erase(it);
+            return failure();
+        }
+        plan.shape = std::move(*shape);
+    }
+
+    if (bindingIndex.has_value()) {
+        if (!plan.bindingAssigned) {
+            plan.bindingIndex = *bindingIndex;
+            plan.bindingAssigned = true;
+        } else if (plan.bindingIndex != *bindingIndex) {
+            return _sequenceOp.emitError("logical value changed VGF binding index");
+        }
+    }
+
+    return &plan;
+}
+
+void ResourcePlanner::appendResourceRequirement(PlannedValue &plan, const ResourceKey &resourceKey, bool isProducer) {
+    if (std::find(plan.resourceOrder.begin(), plan.resourceOrder.end(), resourceKey) == plan.resourceOrder.end()) {
+        plan.resourceOrder.push_back(resourceKey);
+    }
+    if (isProducer) {
+        plan.producerResource = resourceKey;
+    }
+}
+
+void ResourcePlanner::appendAttachment(std::vector<SegmentAttachment> &attachments, SegmentId segmentId, Value value,
+                                       bool isOutput, const ResourceKey &resourceKey,
+                                       std::optional<int64_t> descriptorSet, std::optional<uint32_t> descriptorBinding,
+                                       bool isProducer) {
+    auto planIt = _resourcePlan.plannedValues.find(value);
+    assert(planIt != _resourcePlan.plannedValues.end());
+    appendResourceRequirement(planIt->second, resourceKey, isProducer);
+    attachments.push_back({segmentId, value, isOutput, resourceKey, descriptorSet, descriptorBinding});
+}
+
+LogicalResult ResourcePlanner::collectSequenceInputs() {
+    for (auto operand : _sequenceOp.getArguments()) {
+        if (failed(ensurePlannedValue(operand, llvm::cast<BlockArgument>(operand).getArgNumber()))) {
+            return failure();
+        }
+
+        const WalkResult inputWalkResult = _sequenceOp.walk([&](vgf::SegmentOp segmentOp) {
+            const auto segmentType = segmentOp.getSegmentType();
+            const auto segmentId = segmentOp->getAttrOfType<IntegerAttr>("segment_id").getUInt();
+            const auto segmentName = segmentOp.getSymName().str();
+            auto *runSegmentOp = segmentOp->getNextNode();
+
+            WalkResult segmentWalkResult;
+            if (segmentType == vgf::SegmentTypeEnum::COMPUTE) {
+                segmentWalkResult = segmentOp.walk([&](vgf::ShaderPlaceholderOp shaderPlaceholderOp) {
+                    size_t ioIndex = 0;
+                    for (const auto &[inputBinding, inputDescriptorType, inputVkFormat, inputDescriptorSet, input] :
+                         llvm::zip(shaderPlaceholderOp.getInputBindings(),
+                                   shaderPlaceholderOp.getInputVkDescriptorTypes(),
+                                   shaderPlaceholderOp.getInputVkFormats(),
+                                   shaderPlaceholderOp.getInputDescriptorSets(), runSegmentOp->getOperands())) {
+                        if (input == operand) {
+                            const ResourceViewKey view = {
+                                NameToDescriptorType(llvm::cast<StringAttr>(inputDescriptorType).str()),
+                                NameToFormatType(llvm::cast<StringAttr>(inputVkFormat).str())};
+                            appendAttachment(
+                                _resourcePlan.sequenceInputAttachments, segmentId, input, false,
+                                makeResourceKey(ResourceCategory::INPUT, view,
+                                                getOptionalSamplerConfigValues(
+                                                    shaderPlaceholderOp.getInputSamplerConfigsAttr(), ioIndex)),
+                                inputDescriptorSet, static_cast<uint32_t>(inputBinding));
+                        }
+                        ++ioIndex;
+                    }
+
+                    return WalkResult::advance();
+                });
+            } else if (segmentType == vgf::SegmentTypeEnum::GRAPH) {
+                segmentWalkResult = segmentOp.walk([&](spirv::ModuleOp spirvModuleOp) {
+                    WalkResult spirvModuleWalkResult = spirvModuleOp.walk([&](spirv::GraphARMOp) {
+                        for (const auto &input : runSegmentOp->getOperands()) {
+                            if (input == operand) {
+                                ResourceViewKey view;
+                                if (getGraphView(input, "input", segmentName, view).failed()) {
+                                    return WalkResult::interrupt();
+                                }
+                                appendAttachment(_resourcePlan.sequenceInputAttachments, segmentId, input, false,
+                                                 makeResourceKey(ResourceCategory::INPUT, view));
+                            }
+                        }
+
+                        return WalkResult::advance();
+                    });
+                    return spirvModuleWalkResult;
+                });
+            } else {
+                llvm::errs() << "Invalid segment type in sequence module\n";
+                return WalkResult::interrupt();
+            }
+            return segmentWalkResult;
+        });
+
+        if (inputWalkResult.wasInterrupted()) {
+            return failure();
+        }
+    }
+
+    return success();
+}
+
+LogicalResult ResourcePlanner::collectIntermediates() {
+    const WalkResult intermediateWalkResult = _sequenceOp.walk([&](vgf::SegmentOp segmentOp) {
+        const auto segmentType = segmentOp.getSegmentType();
+        const auto segmentId = segmentOp->getAttrOfType<IntegerAttr>("segment_id").getUInt();
+        const auto segmentName = segmentOp.getSymName().str();
+        auto *runSegmentOp = segmentOp->getNextNode();
+
+        WalkResult segmentWalkResult;
+        if (segmentType == vgf::SegmentTypeEnum::COMPUTE) {
+            segmentWalkResult = segmentOp.walk([&](vgf::ShaderPlaceholderOp shaderPlaceholderOp) {
+                size_t ioIndex = 0;
+                for (const auto &[inputBinding, inputDescriptorType, inputVkFormat, inputDescriptorSet, input] :
+                     llvm::zip(shaderPlaceholderOp.getInputBindings(), shaderPlaceholderOp.getInputVkDescriptorTypes(),
+                               shaderPlaceholderOp.getInputVkFormats(), shaderPlaceholderOp.getInputDescriptorSets(),
+                               runSegmentOp->getOperands())) {
+                    if (!isSequenceInputOperand(input)) {
+                        auto plan = ensurePlannedValue(input);
+                        if (failed(plan)) {
+                            return WalkResult::interrupt();
+                        }
+                        auto &plannedValue = **plan;
+                        if (!plannedValue.bindingAssigned) {
+                            plannedValue.bindingIndex = _bindingId++;
+                            plannedValue.bindingAssigned = true;
+                            _resourcePlan.intermediateValues.push_back(input);
+                        }
+
+                        const ResourceViewKey view = {
+                            NameToDescriptorType(llvm::cast<StringAttr>(inputDescriptorType).str()),
+                            NameToFormatType(llvm::cast<StringAttr>(inputVkFormat).str())};
+                        appendAttachment(
+                            _resourcePlan.intermediateAttachments, segmentId, input, false,
+                            makeResourceKey(ResourceCategory::INTERMEDIATE, view,
+                                            getOptionalSamplerConfigValues(
+                                                shaderPlaceholderOp.getInputSamplerConfigsAttr(), ioIndex)),
+                            inputDescriptorSet, static_cast<uint32_t>(inputBinding));
+                    }
+                    ++ioIndex;
+                }
+
+                ioIndex = 0;
+                for (const auto &[outputBinding, outputDescriptorType, outputVkFormat, outputDescriptorSet, result] :
+                     llvm::zip(shaderPlaceholderOp.getOutputBindings(),
+                               shaderPlaceholderOp.getOutputVkDescriptorTypes(),
+                               shaderPlaceholderOp.getOutputVkFormats(), shaderPlaceholderOp.getOutputDescriptorSets(),
+                               runSegmentOp->getResults())) {
+                    if (!isSequenceOutputOperand(result)) {
+                        auto plan = ensurePlannedValue(result);
+                        if (failed(plan)) {
+                            return WalkResult::interrupt();
+                        }
+                        auto &plannedValue = **plan;
+                        if (!plannedValue.bindingAssigned) {
+                            plannedValue.bindingIndex = _bindingId++;
+                            plannedValue.bindingAssigned = true;
+                            _resourcePlan.intermediateValues.push_back(result);
+                        }
+
+                        const ResourceViewKey view = {
+                            NameToDescriptorType(llvm::cast<StringAttr>(outputDescriptorType).str()),
+                            NameToFormatType(llvm::cast<StringAttr>(outputVkFormat).str())};
+                        appendAttachment(
+                            _resourcePlan.intermediateAttachments, segmentId, result, true,
+                            makeResourceKey(ResourceCategory::INTERMEDIATE, view,
+                                            getOptionalSamplerConfigValues(
+                                                shaderPlaceholderOp.getOutputSamplerConfigsAttr(), ioIndex)),
+                            outputDescriptorSet, static_cast<uint32_t>(outputBinding), true);
+                    }
+                    ++ioIndex;
+                }
+                return WalkResult::advance();
+            });
+        } else if (segmentType == vgf::SegmentTypeEnum::GRAPH) {
+            segmentWalkResult = segmentOp.walk([&](spirv::ModuleOp spirvModuleOp) {
+                WalkResult spirvModuleWalkResult = spirvModuleOp.walk([&](spirv::GraphARMOp) {
+                    for (const auto &input : runSegmentOp->getOperands()) {
+                        if (!isSequenceInputOperand(input)) {
+                            ResourceViewKey view;
+                            if (getGraphView(input, "input", segmentName, view).failed()) {
+                                return WalkResult::interrupt();
+                            }
+
+                            auto plan = ensurePlannedValue(input);
+                            if (failed(plan)) {
+                                return WalkResult::interrupt();
+                            }
+                            auto &plannedValue = **plan;
+                            if (!plannedValue.bindingAssigned) {
+                                plannedValue.bindingIndex = _bindingId++;
+                                plannedValue.bindingAssigned = true;
+                                _resourcePlan.intermediateValues.push_back(input);
+                            }
+
+                            appendAttachment(_resourcePlan.intermediateAttachments, segmentId, input, false,
+                                             makeResourceKey(ResourceCategory::INTERMEDIATE, view));
+                        }
+                    }
+
+                    for (const auto &result : runSegmentOp->getResults()) {
+                        if (!isSequenceOutputOperand(result)) {
+                            ResourceViewKey view;
+                            if (getGraphView(result, "result", segmentName, view).failed()) {
+                                return WalkResult::interrupt();
+                            }
+
+                            auto plan = ensurePlannedValue(result);
+                            if (failed(plan)) {
+                                return WalkResult::interrupt();
+                            }
+                            auto &plannedValue = **plan;
+                            if (!plannedValue.bindingAssigned) {
+                                plannedValue.bindingIndex = _bindingId++;
+                                plannedValue.bindingAssigned = true;
+                                _resourcePlan.intermediateValues.push_back(result);
+                            }
+
+                            appendAttachment(_resourcePlan.intermediateAttachments, segmentId, result, true,
+                                             makeResourceKey(ResourceCategory::INTERMEDIATE, view), std::nullopt,
+                                             std::nullopt, true);
+                        }
+                    }
+                    return WalkResult::advance();
+                });
+                return spirvModuleWalkResult;
+            });
+        } else {
+            return WalkResult::interrupt();
+        }
+        return segmentWalkResult;
+    });
+
+    return success(!intermediateWalkResult.wasInterrupted());
+}
+
+bool ResourcePlanner::hasResourceCategory(const PlannedValue &plan, ResourceCategory category) const {
+    return std::any_of(plan.resourceOrder.begin(), plan.resourceOrder.end(),
+                       [&](const ResourceKey &key) { return key.category == category; });
+}
+
+std::optional<ResourceKey> ResourcePlanner::getCanonicalResource(const PlannedValue &plan,
+                                                                 ResourceCategory category) const {
+    if (plan.producerResource.has_value() && plan.producerResource->category == category) {
+        return plan.producerResource;
+    }
+    auto resourceIt = std::find_if(plan.resourceOrder.begin(), plan.resourceOrder.end(),
+                                   [&](const ResourceKey &key) { return key.category == category; });
+    if (resourceIt == plan.resourceOrder.end()) {
+        return std::nullopt;
+    }
+    return *resourceIt;
+}
+
+LogicalResult ResourcePlanner::collectSequenceOutputs() {
+    for (auto operand : _sequenceOutputOp->getOperands()) {
+        auto plan = ensurePlannedValue(operand);
+        if (failed(plan)) {
+            return failure();
+        }
+        auto &plannedValue = **plan;
+        if (!plannedValue.bindingAssigned) {
+            plannedValue.bindingIndex = _bindingId++;
+            plannedValue.bindingAssigned = true;
+        }
+
+        const WalkResult outputWalkResult = _sequenceOp.walk([&](vgf::SegmentOp segmentOp) {
+            const auto segmentType = segmentOp.getSegmentType();
+            const auto segmentId = segmentOp->getAttrOfType<IntegerAttr>("segment_id").getUInt();
+            const auto segmentName = segmentOp.getSymName().str();
+            auto *runSegmentOp = segmentOp->getNextNode();
+
+            WalkResult segmentWalkResult;
+            if (segmentType == vgf::SegmentTypeEnum::COMPUTE) {
+                segmentWalkResult = segmentOp.walk([&](vgf::ShaderPlaceholderOp shaderPlaceholderOp) {
+                    size_t ioIndex = 0;
+                    for (const auto &[outputBinding, outputDescriptorType, outputVkFormat, outputDescriptorSet,
+                                      result] :
+                         llvm::zip(shaderPlaceholderOp.getOutputBindings(),
+                                   shaderPlaceholderOp.getOutputVkDescriptorTypes(),
+                                   shaderPlaceholderOp.getOutputVkFormats(),
+                                   shaderPlaceholderOp.getOutputDescriptorSets(), runSegmentOp->getResults())) {
+                        if (result == operand) {
+                            const ResourceViewKey view = {
+                                NameToDescriptorType(llvm::cast<StringAttr>(outputDescriptorType).str()),
+                                NameToFormatType(llvm::cast<StringAttr>(outputVkFormat).str())};
+                            appendAttachment(
+                                _resourcePlan.sequenceOutputAttachments, segmentId, result, true,
+                                makeResourceKey(ResourceCategory::OUTPUT, view,
+                                                getOptionalSamplerConfigValues(
+                                                    shaderPlaceholderOp.getOutputSamplerConfigsAttr(), ioIndex)),
+                                outputDescriptorSet, static_cast<uint32_t>(outputBinding), true);
+                        }
+                        ++ioIndex;
+                    }
+
+                    return WalkResult::advance();
+                });
+            } else if (segmentType == vgf::SegmentTypeEnum::GRAPH) {
+                segmentWalkResult = segmentOp.walk([&](spirv::ModuleOp spirvModuleOp) {
+                    WalkResult spirvModuleWalkResult = spirvModuleOp.walk([&](spirv::GraphARMOp) {
+                        for (const auto &result : runSegmentOp->getResults()) {
+                            if (result == operand) {
+                                ResourceViewKey view;
+                                if (getGraphView(result, "result", segmentName, view).failed()) {
+                                    return WalkResult::interrupt();
+                                }
+                                appendAttachment(_resourcePlan.sequenceOutputAttachments, segmentId, result, true,
+                                                 makeResourceKey(ResourceCategory::OUTPUT, view), std::nullopt,
+                                                 std::nullopt, true);
+                            }
+                        }
+
+                        return WalkResult::advance();
+                    });
+                    return spirvModuleWalkResult;
+                });
+            } else {
+                return WalkResult::interrupt();
+            }
+            return segmentWalkResult;
+        });
+
+        if (outputWalkResult.wasInterrupted()) {
+            return failure();
+        }
+
+        if (!hasResourceCategory(plannedValue, ResourceCategory::OUTPUT)) {
+            ResourceViewKey view;
+            if (getGraphView(operand, "result", "sequence_output", view).failed()) {
+                return failure();
+            }
+            appendResourceRequirement(plannedValue, makeResourceKey(ResourceCategory::OUTPUT, view), true);
+        }
+    }
+
+    return success();
+}
+
+void ResourcePlanner::finalizePlannedValues() {
+    for (auto operand : _sequenceOp.getArguments()) {
+        finalizePlannedValue(operand);
+    }
+    for (auto value : _resourcePlan.intermediateValues) {
+        finalizePlannedValue(value);
+    }
+    for (auto operand : _sequenceOutputOp->getOperands()) {
+        finalizePlannedValue(operand);
+    }
+}
+
+void ResourcePlanner::finalizePlannedValue(Value value) {
+    auto planIt = _resourcePlan.plannedValues.find(value);
+    if (planIt == _resourcePlan.plannedValues.end()) {
+        return;
+    }
+
+    auto &plan = planIt->second;
+    if (plan.resourceOrder.empty()) {
+        return;
+    }
+
+    if (plan.resourceOrder.size() > 1 && !plan.aliasGroupId.has_value()) {
+        assert(_nextAliasGroupId != INVALID_ALIAS_GROUP_ID && "exhausted alias group ids");
+        plan.aliasGroupId = _nextAliasGroupId++;
+    }
+}
+
+ResourcePlanEncoder::ResourcePlanEncoder(const ResourcePlan &resourcePlan, VGFBuilder &vgfBuilder)
+    : _resourcePlan(resourcePlan), _vgfBuilder(vgfBuilder) {}
+
+const std::vector<BindingSlotRef> &EncodedResourcePlan::getSegmentInputBindings(SegmentId segmentId) const {
+    return getSegmentBindings(segmentInputBindings, segmentId);
+}
+
+const std::vector<BindingSlotRef> &EncodedResourcePlan::getSegmentOutputBindings(SegmentId segmentId) const {
+    return getSegmentBindings(segmentOutputBindings, segmentId);
+}
+
+const EncodedResourcePlan &ResourcePlanEncoder::encode() {
+    materializeBindings();
+    return _encodedPlan;
+}
+
+std::optional<ResourceKey> ResourcePlanEncoder::getCanonicalResource(const PlannedValue &plan,
+                                                                     ResourceCategory category) {
+    if (plan.producerResource.has_value() && plan.producerResource->category == category) {
+        return plan.producerResource;
+    }
+    auto resourceIt = std::find_if(plan.resourceOrder.begin(), plan.resourceOrder.end(),
+                                   [&](const ResourceKey &key) { return key.category == category; });
+    if (resourceIt == plan.resourceOrder.end()) {
+        return std::nullopt;
+    }
+    return *resourceIt;
+}
+
+void ResourcePlanEncoder::addBindingToDescriptorSet(SegmentId segmentId, int64_t descriptorSet,
+                                                    BindingSlotRef bindingSlotRef) {
+    const auto descriptorSetIndex = static_cast<uint32_t>(descriptorSet);
+    auto &bindingRefs = _segmentDescriptorSetBindingRefs[segmentId][descriptorSetIndex];
+    if (bindingRefs.insert(bindingSlotRef.reference).second) {
+        _encodedPlan.segmentDescriptorSetBindings[segmentId][descriptorSetIndex].push_back(bindingSlotRef);
+    }
+}
+
+ResourceRef ResourcePlanEncoder::createResource(const PlannedValue &plan, const ResourceKey &resourceKey) {
+    switch (resourceKey.category) {
+    case ResourceCategory::INPUT:
+        return _vgfBuilder.getEncoder()->AddInputResource(resourceKey.view.descriptorType, resourceKey.view.vkFormat,
+                                                          plan.shape, {}, plan.aliasGroupId);
+    case ResourceCategory::OUTPUT:
+        return _vgfBuilder.getEncoder()->AddOutputResource(resourceKey.view.descriptorType, resourceKey.view.vkFormat,
+                                                           plan.shape, {}, plan.aliasGroupId);
+    case ResourceCategory::INTERMEDIATE:
+        return _vgfBuilder.getEncoder()->AddIntermediateResource(
+            resourceKey.view.descriptorType, resourceKey.view.vkFormat, plan.shape, {}, plan.aliasGroupId);
+    case ResourceCategory::CONSTANT:
+        assert(false && "planned VGF resources must not be constants");
+        return ResourceRef{0};
+    }
+    assert(false && "invalid planned VGF resource category");
+    return ResourceRef{0};
+}
+
+void ResourcePlanEncoder::addSamplerConfig(ResourceRef resourceRef, const ResourceKey &resourceKey) {
+    if (!resourceKey.samplerConfig.has_value()) {
+        return;
+    }
+
+    const auto &samplerConfig = *resourceKey.samplerConfig;
+    _vgfBuilder.getEncoder()->AddSamplerConfig(resourceRef, samplerConfig.minFilter, samplerConfig.magFilter,
+                                               samplerConfig.addressModeU, samplerConfig.addressModeV,
+                                               samplerConfig.borderColor);
+}
+
+ResourceRef ResourcePlanEncoder::getOrCreateResource(Value value, const ResourceKey &resourceKey) {
+    auto planIt = _resourcePlan.plannedValues.find(value);
+    assert(planIt != _resourcePlan.plannedValues.end());
+    const auto &plan = planIt->second;
+    auto &encodedValue = _encodedValues[value];
+
+    auto resourceIt = encodedValue.resources.find(resourceKey);
+    if (resourceIt == encodedValue.resources.end()) {
+        const ResourceRef resourceRef = createResource(plan, resourceKey);
+        addSamplerConfig(resourceRef, resourceKey);
+        resourceIt = encodedValue.resources.emplace(resourceKey, resourceRef).first;
+    }
+
+    return resourceIt->second;
+}
+
+BindingSlotRef ResourcePlanEncoder::getOrCreateLogicalBindingSlot(Value value, const ResourceKey &resourceKey) {
+    auto planIt = _resourcePlan.plannedValues.find(value);
+    assert(planIt != _resourcePlan.plannedValues.end());
+    const auto &plan = planIt->second;
+    auto &encodedValue = _encodedValues[value];
+
+    auto bindingSlotIt = encodedValue.logicalBindingSlots.find(resourceKey);
+    if (bindingSlotIt == encodedValue.logicalBindingSlots.end()) {
+        bindingSlotIt = encodedValue.logicalBindingSlots
+                            .emplace(resourceKey, _vgfBuilder.getEncoder()->AddBindingSlot(
+                                                      plan.bindingIndex, getOrCreateResource(value, resourceKey)))
+                            .first;
+    }
+
+    return bindingSlotIt->second;
+}
+
+BindingSlotRef ResourcePlanEncoder::getOrCreateDescriptorBindingSlot(Value value, const ResourceKey &resourceKey,
+                                                                     uint32_t binding) {
+    assert(_resourcePlan.plannedValues.find(value) != _resourcePlan.plannedValues.end());
+    auto &encodedValue = _encodedValues[value];
+
+    const DescriptorBindingKey key = {resourceKey, binding};
+    auto bindingSlotIt = encodedValue.descriptorBindingSlots.find(key);
+    if (bindingSlotIt == encodedValue.descriptorBindingSlots.end()) {
+        bindingSlotIt =
+            encodedValue.descriptorBindingSlots
+                .emplace(key,
+                         _vgfBuilder.getEncoder()->AddBindingSlot(binding, getOrCreateResource(value, resourceKey)))
+                .first;
+    }
+
+    return bindingSlotIt->second;
+}
+
+void ResourcePlanEncoder::materializeAttachment(const SegmentAttachment &attachment) {
+    const auto bindingSlotRef = getOrCreateLogicalBindingSlot(attachment.value, attachment.resourceKey);
+    auto &segmentBindings = attachment.isOutput ? _encodedPlan.segmentOutputBindings[attachment.segmentId]
+                                                : _encodedPlan.segmentInputBindings[attachment.segmentId];
+    segmentBindings.push_back(bindingSlotRef);
+
+    if (attachment.descriptorSet.has_value() && attachment.descriptorBinding.has_value()) {
+        addBindingToDescriptorSet(
+            attachment.segmentId, *attachment.descriptorSet,
+            getOrCreateDescriptorBindingSlot(attachment.value, attachment.resourceKey, *attachment.descriptorBinding));
+    }
+}
+
+void ResourcePlanEncoder::materializeBindings() {
+    for (auto operand : _resourcePlan.sequenceInputValues) {
+        auto planIt = _resourcePlan.plannedValues.find(operand);
+        if (planIt == _resourcePlan.plannedValues.end()) {
+            continue;
+        }
+        const auto canonicalResource = getCanonicalResource(planIt->second, ResourceCategory::INPUT);
+        if (!canonicalResource.has_value()) {
+            continue;
+        }
+        _encodedPlan.sequenceInputBindings.push_back(getOrCreateLogicalBindingSlot(operand, *canonicalResource));
+    }
+
+    if (_encodedPlan.sequenceInputBindings.size() < _resourcePlan.sequenceInputValues.size()) {
+        llvm::errs() << "Warning: Sequence module contains unused arguments\n";
+    }
+
+    for (const auto &attachment : _resourcePlan.sequenceInputAttachments) {
+        materializeAttachment(attachment);
+    }
+    for (const auto &attachment : _resourcePlan.intermediateAttachments) {
+        materializeAttachment(attachment);
+    }
+
+    for (auto operand : _resourcePlan.sequenceOutputValues) {
+        auto planIt = _resourcePlan.plannedValues.find(operand);
+        if (planIt == _resourcePlan.plannedValues.end()) {
+            continue;
+        }
+        const auto canonicalResource = getCanonicalResource(planIt->second, ResourceCategory::OUTPUT);
+        if (!canonicalResource.has_value()) {
+            continue;
+        }
+        _encodedPlan.sequenceOutputBindings.push_back(getOrCreateLogicalBindingSlot(operand, *canonicalResource));
+    }
+    for (const auto &attachment : _resourcePlan.sequenceOutputAttachments) {
+        materializeAttachment(attachment);
+    }
+}
+
+} // namespace mlir::model_converter_passes::detail

--- a/src/conversion/resource_planner.hpp
+++ b/src/conversion/resource_planner.hpp
@@ -1,0 +1,189 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+#pragma once
+
+#include "include/passes.hpp"
+#include "vgf/encoder.hpp"
+#include "vgf_builder.hpp"
+
+#include <limits>
+#include <map>
+#include <optional>
+#include <set>
+#include <tuple>
+#include <vector>
+
+namespace mlir::model_converter_passes::detail {
+
+using namespace mlsdk::vgflib;
+
+using SegmentId = uint64_t;
+
+constexpr uint32_t UNSET_SAMPLER_VALUE = std::numeric_limits<uint32_t>::max();
+
+struct SamplerConfigValues {
+    uint32_t minFilter = UNSET_SAMPLER_VALUE;
+    uint32_t magFilter = UNSET_SAMPLER_VALUE;
+    uint32_t addressModeU = UNSET_SAMPLER_VALUE;
+    uint32_t addressModeV = UNSET_SAMPLER_VALUE;
+    uint32_t borderColor = UNSET_SAMPLER_VALUE;
+
+    bool operator==(const SamplerConfigValues &other) const {
+        return minFilter == other.minFilter && magFilter == other.magFilter && addressModeU == other.addressModeU &&
+               addressModeV == other.addressModeV && borderColor == other.borderColor;
+    }
+
+    bool operator<(const SamplerConfigValues &other) const {
+        return std::tie(minFilter, magFilter, addressModeU, addressModeV, borderColor) <
+               std::tie(other.minFilter, other.magFilter, other.addressModeU, other.addressModeV, other.borderColor);
+    }
+};
+
+struct ResourceViewKey {
+    DescriptorType descriptorType;
+    FormatType vkFormat;
+
+    bool operator==(const ResourceViewKey &other) const {
+        return descriptorType == other.descriptorType && vkFormat == other.vkFormat;
+    }
+
+    bool operator<(const ResourceViewKey &other) const {
+        return std::tie(descriptorType, vkFormat) < std::tie(other.descriptorType, other.vkFormat);
+    }
+};
+
+struct ResourceKey {
+    ResourceCategory category;
+    ResourceViewKey view;
+    std::optional<SamplerConfigValues> samplerConfig;
+
+    bool operator==(const ResourceKey &other) const {
+        return category == other.category && view == other.view && samplerConfig == other.samplerConfig;
+    }
+
+    bool operator<(const ResourceKey &other) const {
+        return std::tie(category, view.descriptorType, view.vkFormat, samplerConfig) <
+               std::tie(other.category, other.view.descriptorType, other.view.vkFormat, other.samplerConfig);
+    }
+};
+
+struct DescriptorBindingKey {
+    ResourceKey resourceKey;
+    uint32_t binding;
+
+    bool operator<(const DescriptorBindingKey &other) const {
+        return std::tie(resourceKey, binding) < std::tie(other.resourceKey, other.binding);
+    }
+};
+
+struct PlannedValue {
+    uint32_t bindingIndex = 0;
+    bool bindingAssigned = false;
+    std::vector<int64_t> shape;
+    std::vector<ResourceKey> resourceOrder;
+    std::optional<ResourceKey> producerResource;
+    std::optional<AliasGroupId> aliasGroupId;
+};
+
+struct SegmentAttachment {
+    SegmentId segmentId;
+    Value value;
+    bool isOutput = false;
+    ResourceKey resourceKey;
+    std::optional<int64_t> descriptorSet;
+    std::optional<uint32_t> descriptorBinding;
+};
+
+struct ResourcePlan {
+    DenseMap<Value, PlannedValue> plannedValues;
+    std::vector<Value> sequenceInputValues;
+    std::vector<Value> intermediateValues;
+    std::vector<Value> sequenceOutputValues;
+    std::vector<SegmentAttachment> sequenceInputAttachments;
+    std::vector<SegmentAttachment> intermediateAttachments;
+    std::vector<SegmentAttachment> sequenceOutputAttachments;
+};
+
+struct EncodedResourcePlan {
+    std::vector<BindingSlotRef> sequenceInputBindings;
+    std::vector<BindingSlotRef> sequenceOutputBindings;
+    std::map<SegmentId, std::vector<BindingSlotRef>> segmentInputBindings;
+    std::map<SegmentId, std::vector<BindingSlotRef>> segmentOutputBindings;
+    std::map<SegmentId, std::map<uint32_t, std::vector<BindingSlotRef>>> segmentDescriptorSetBindings;
+
+    const std::vector<BindingSlotRef> &getSegmentInputBindings(SegmentId segmentId) const;
+    const std::vector<BindingSlotRef> &getSegmentOutputBindings(SegmentId segmentId) const;
+};
+
+struct EncodedPlannedValue {
+    std::map<ResourceKey, ResourceRef> resources;
+    std::map<ResourceKey, BindingSlotRef> logicalBindingSlots;
+    std::map<DescriptorBindingKey, BindingSlotRef> descriptorBindingSlots;
+};
+
+class ResourcePlanner {
+  public:
+    explicit ResourcePlanner(vgf::SequenceOp &sequenceOp);
+
+    LogicalResult buildPlan();
+
+    const ResourcePlan &getPlan() const;
+
+  private:
+    bool isSequenceInputOperand(Value operand) const;
+    bool isSequenceOutputOperand(Value operand) const;
+    bool getSequenceInputUnsigned(uint32_t inputIndex) const;
+    bool getSequenceOutputUnsigned(uint32_t outputIndex) const;
+    FailureOr<std::vector<int64_t>> getValueShape(Value value) const;
+    LogicalResult getGraphView(Value value, StringRef role, StringRef segmentName, ResourceViewKey &view) const;
+    static ResourceKey makeResourceKey(ResourceCategory category, const ResourceViewKey &view,
+                                       std::optional<SamplerConfigValues> samplerConfig = std::nullopt);
+    FailureOr<PlannedValue *> ensurePlannedValue(Value value, std::optional<uint32_t> bindingIndex = std::nullopt);
+    void appendResourceRequirement(PlannedValue &plan, const ResourceKey &resourceKey, bool isProducer);
+    void appendAttachment(std::vector<SegmentAttachment> &attachments, SegmentId segmentId, Value value, bool isOutput,
+                          const ResourceKey &resourceKey, std::optional<int64_t> descriptorSet = std::nullopt,
+                          std::optional<uint32_t> descriptorBinding = std::nullopt, bool isProducer = false);
+    LogicalResult collectSequenceInputs();
+    LogicalResult collectIntermediates();
+    bool hasResourceCategory(const PlannedValue &plan, ResourceCategory category) const;
+    std::optional<ResourceKey> getCanonicalResource(const PlannedValue &plan, ResourceCategory category) const;
+    LogicalResult collectSequenceOutputs();
+    void finalizePlannedValues();
+    void finalizePlannedValue(Value value);
+
+    vgf::SequenceOp &_sequenceOp;
+    Operation *_sequenceOutputOp = nullptr;
+    DenseMap<Value, uint32_t> _sequenceOutputIndices;
+    ResourcePlan _resourcePlan;
+    AliasGroupId _nextAliasGroupId = 0;
+    uint32_t _bindingId = 0;
+};
+
+class ResourcePlanEncoder {
+  public:
+    ResourcePlanEncoder(const ResourcePlan &resourcePlan, VGFBuilder &vgfBuilder);
+
+    const EncodedResourcePlan &encode();
+
+  private:
+    static std::optional<ResourceKey> getCanonicalResource(const PlannedValue &plan, ResourceCategory category);
+    void addBindingToDescriptorSet(SegmentId segmentId, int64_t descriptorSet, BindingSlotRef bindingSlotRef);
+    ResourceRef createResource(const PlannedValue &plan, const ResourceKey &resourceKey);
+    void addSamplerConfig(ResourceRef resourceRef, const ResourceKey &resourceKey);
+    ResourceRef getOrCreateResource(Value value, const ResourceKey &resourceKey);
+    BindingSlotRef getOrCreateLogicalBindingSlot(Value value, const ResourceKey &resourceKey);
+    BindingSlotRef getOrCreateDescriptorBindingSlot(Value value, const ResourceKey &resourceKey, uint32_t binding);
+    void materializeAttachment(const SegmentAttachment &attachment);
+    void materializeBindings();
+
+    const ResourcePlan &_resourcePlan;
+    VGFBuilder &_vgfBuilder;
+    EncodedResourcePlan _encodedPlan;
+    DenseMap<Value, EncodedPlannedValue> _encodedValues;
+    std::map<SegmentId, std::map<uint32_t, std::set<uint32_t>>> _segmentDescriptorSetBindingRefs;
+};
+
+} // namespace mlir::model_converter_passes::detail

--- a/src/conversion/serialize_vgf.cpp
+++ b/src/conversion/serialize_vgf.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
+#include "conversion/resource_planner.hpp"
 #include "include/passes.hpp"
 #include "mlir/Target/SPIRV/Serialization.h"
 #include "utils.hpp"
@@ -10,19 +11,14 @@
 #include "vgf_builder.hpp"
 #include "llvm/Support/Casting.h"
 
-#define VGFLIB_VK_HELPERS
-#include "vgf/vulkan_helpers.generated.hpp"
-
 #include <algorithm>
 #include <cassert>
 #include <fstream>
-#include <functional>
 #include <iostream>
 #include <iterator>
-#include <limits>
 #include <map>
 #include <optional>
-#include <set>
+#include <vector>
 
 using namespace mlsdk::vgflib;
 
@@ -30,13 +26,6 @@ namespace mlir::model_converter_passes {
 #define GEN_PASS_DEF_SERIALIZEVGFPASS
 #include "passes.hpp.inc"
 namespace {
-
-using SegmentId = uint64_t;
-
-// As defined in vulkan_core.h
-// FIXME: We may choose to link in vulkan_headers directly once we need to
-// support more types, but for now we just need this one value so here it is.
-constexpr DescriptorType DESCRIPTOR_TYPE_TENSOR_ARM = 1000460000;
 
 std::optional<ShaderType> toShaderType(const StringRef language) {
     if (language == "GLSL") {
@@ -48,64 +37,7 @@ std::optional<ShaderType> toShaderType(const StringRef language) {
     return std::nullopt;
 }
 
-constexpr uint32_t UNSET_SAMPLER_VALUE = std::numeric_limits<uint32_t>::max();
-
-struct SamplerConfigValues {
-    uint32_t minFilter = UNSET_SAMPLER_VALUE;
-    uint32_t magFilter = UNSET_SAMPLER_VALUE;
-    uint32_t addressModeU = UNSET_SAMPLER_VALUE;
-    uint32_t addressModeV = UNSET_SAMPLER_VALUE;
-    uint32_t borderColor = UNSET_SAMPLER_VALUE;
-};
-
-template <typename ParseFn> uint32_t parseSamplerEnumValue(const StringRef name, ParseFn &&parseFn) {
-    if (name.empty()) {
-        return UNSET_SAMPLER_VALUE;
-    }
-    const auto value = parseFn(name.str());
-    return value < 0 ? UNSET_SAMPLER_VALUE : static_cast<uint32_t>(value);
-}
-
-uint32_t parseSamplerFilter(const StringRef name) { return parseSamplerEnumValue(name, NameToFilterType); }
-
-uint32_t parseSamplerAddressMode(const StringRef name) {
-    return parseSamplerEnumValue(name, NameToSamplerAddressModeType);
-}
-
-uint32_t parseSamplerBorderColor(const StringRef name) { return parseSamplerEnumValue(name, NameToBorderColorType); }
-
-DictionaryAttr getSamplerConfig(ArrayAttr samplerConfigsAttr, size_t index) {
-    if (!samplerConfigsAttr || index >= samplerConfigsAttr.size()) {
-        return nullptr;
-    }
-    if (index > static_cast<size_t>(std::numeric_limits<unsigned>::max())) {
-        return nullptr;
-    }
-    return llvm::dyn_cast<DictionaryAttr>(samplerConfigsAttr[static_cast<unsigned>(index)]);
-}
-
-uint32_t getSamplerValue(DictionaryAttr samplerConfigAttr, StringRef key,
-                         const std::function<uint32_t(StringRef)> &parseFn) {
-    if (!samplerConfigAttr) {
-        return UNSET_SAMPLER_VALUE;
-    }
-    auto valueAttr = samplerConfigAttr.getAs<StringAttr>(key);
-    if (!valueAttr) {
-        return UNSET_SAMPLER_VALUE;
-    }
-    return parseFn(valueAttr.getValue());
-}
-
-SamplerConfigValues getSamplerConfigValues(ArrayAttr samplerConfigsAttr, size_t index) {
-    const auto samplerConfigAttr = getSamplerConfig(samplerConfigsAttr, index);
-    SamplerConfigValues samplerConfig;
-    samplerConfig.minFilter = getSamplerValue(samplerConfigAttr, "min_filter", parseSamplerFilter);
-    samplerConfig.magFilter = getSamplerValue(samplerConfigAttr, "mag_filter", parseSamplerFilter);
-    samplerConfig.addressModeU = getSamplerValue(samplerConfigAttr, "address_mode_u", parseSamplerAddressMode);
-    samplerConfig.addressModeV = getSamplerValue(samplerConfigAttr, "address_mode_v", parseSamplerAddressMode);
-    samplerConfig.borderColor = getSamplerValue(samplerConfigAttr, "border_color", parseSamplerBorderColor);
-    return samplerConfig;
-}
+using detail::ResourcePlanEncoder;
 
 class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
   public:
@@ -156,547 +88,22 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
             }
         }
 
-        auto isSequenceInputOperand = [&](Value operand) {
-            return std::any_of(sequenceOp.getArguments().begin(), sequenceOp.getArguments().end(),
-                               [&](const Value sequenceOpArgument) { return sequenceOpArgument == operand; });
-        };
-
-        auto *sequenceOutputOp = sequenceOp.front().getTerminator();
-        auto isSequenceOutputOperand = [&](Value operand) {
-            return std::any_of(sequenceOutputOp->getOperands().begin(), sequenceOutputOp->getOperands().end(),
-                               [&](const Value sequenceOutputOperand) { return sequenceOutputOperand == operand; });
-        };
-
-        DenseMap<Value, std::shared_ptr<BindingSlotRef>> mapOperandsAndBindingRef;
-        DenseMap<Value, std::shared_ptr<ResourceRef>> mapOperandsAndResourceRef;
-        DenseMap<Value, uint32_t> mapOperandsAndBindingIndex;
-        DenseMap<Value, DescriptorType> mapOperandsAndDescriptorType;
-        DenseMap<Value, AliasGroupId> mapOperandsAndAliasGroupId;
-        DenseMap<Value, std::map<uint32_t, std::shared_ptr<ResourceRef>>> mapOperandsAndAliasedResourceRef;
-        DenseMap<Value, std::map<uint32_t, BindingSlotRef>> mapOperandsAndDescriptorBindingRef;
-        std::map<SegmentId, std::vector<BindingSlotRef>> mapSegmentInputBindings = {};
-        std::map<SegmentId, std::vector<BindingSlotRef>> mapSegmentOutputBindings = {};
-        std::map<SegmentId, std::map<uint32_t, std::vector<BindingSlotRef>>> mapSegmentDescriptorSetBindings = {};
-        std::map<SegmentId, std::map<uint32_t, std::set<uint32_t>>> mapSegmentDescriptorSetBindingRefs = {};
-        AliasGroupId nextAliasGroupId = 0;
-
-        auto rememberOperandResource = [&](Value operand, DescriptorType descriptorType, uint32_t bindingIndex,
-                                           const std::shared_ptr<ResourceRef> &resourceRef,
-                                           const std::shared_ptr<BindingSlotRef> &bindingSlotRef) {
-            mapOperandsAndResourceRef[operand] = resourceRef;
-            mapOperandsAndBindingRef[operand] = bindingSlotRef;
-            mapOperandsAndBindingIndex[operand] = bindingIndex;
-            mapOperandsAndDescriptorType[operand] = descriptorType;
-        };
-
-        auto addBindingToDescriptorSet = [&](const SegmentId segmentId, const int64_t descriptorSet,
-                                             const BindingSlotRef bindingSlotRef) {
-            const auto descriptorSetIndex = static_cast<uint32_t>(descriptorSet);
-            auto &bindingRefs = mapSegmentDescriptorSetBindingRefs[segmentId][descriptorSetIndex];
-            if (bindingRefs.insert(bindingSlotRef.reference).second) {
-                mapSegmentDescriptorSetBindings[segmentId][descriptorSetIndex].push_back(bindingSlotRef);
-            }
-        };
-
-        auto getDescriptorSetBinding = [&](Value operand, uint32_t binding) {
-            auto &descriptorBindings = mapOperandsAndDescriptorBindingRef[operand];
-            auto descriptorBindingIt = descriptorBindings.find(binding);
-            if (descriptorBindingIt == descriptorBindings.end()) {
-                auto resourceIt = mapOperandsAndResourceRef.find(operand);
-                assert(resourceIt != mapOperandsAndResourceRef.end());
-                descriptorBindingIt =
-                    descriptorBindings
-                        .emplace(binding, _VGFBuilder->getEncoder()->AddBindingSlot(binding, *(resourceIt->second)))
-                        .first;
-            }
-            return descriptorBindingIt->second;
-        };
-
-        auto getOrCreateAliasGroupId = [&](Value operand) -> AliasGroupId {
-            auto aliasGroupIt = mapOperandsAndAliasGroupId.find(operand);
-            if (aliasGroupIt == mapOperandsAndAliasGroupId.end()) {
-                assert(nextAliasGroupId != INVALID_ALIAS_GROUP_ID && "exhausted alias group ids");
-                auto resourceIt = mapOperandsAndResourceRef.find(operand);
-                assert(resourceIt != mapOperandsAndResourceRef.end());
-                const AliasGroupId aliasGroupId = nextAliasGroupId++;
-                _VGFBuilder->getEncoder()->SetAliasGroup(*(resourceIt->second), aliasGroupId);
-                aliasGroupIt = mapOperandsAndAliasGroupId.insert({operand, aliasGroupId}).first;
-            }
-            return aliasGroupIt->second;
-        };
-
-        auto getOrCreateAliasedResource = [&](Value operand, ResourceCategory category, DescriptorType descriptorType,
-                                              FormatType vkFormat,
-                                              const ShapedType type) -> std::shared_ptr<ResourceRef> {
-            auto &aliasedResources = mapOperandsAndAliasedResourceRef[operand];
-            const auto aliasKey = static_cast<uint32_t>(descriptorType);
-            auto aliasIt = aliasedResources.find(aliasKey);
-            if (aliasIt == aliasedResources.end()) {
-                const AliasGroupId aliasGroupId = getOrCreateAliasGroupId(operand);
-                switch (category) {
-                case ResourceCategory::INPUT:
-                    aliasIt = aliasedResources
-                                  .emplace(aliasKey,
-                                           std::make_shared<ResourceRef>(_VGFBuilder->getEncoder()->AddInputResource(
-                                               descriptorType, vkFormat, type.getShape(), {}, aliasGroupId)))
-                                  .first;
-                    break;
-                case ResourceCategory::OUTPUT:
-                    aliasIt = aliasedResources
-                                  .emplace(aliasKey,
-                                           std::make_shared<ResourceRef>(_VGFBuilder->getEncoder()->AddOutputResource(
-                                               descriptorType, vkFormat, type.getShape(), {}, aliasGroupId)))
-                                  .first;
-                    break;
-                case ResourceCategory::INTERMEDIATE:
-                    aliasIt =
-                        aliasedResources
-                            .emplace(aliasKey,
-                                     std::make_shared<ResourceRef>(_VGFBuilder->getEncoder()->AddIntermediateResource(
-                                         descriptorType, vkFormat, type.getShape(), {}, aliasGroupId)))
-                            .first;
-                    break;
-                case ResourceCategory::CONSTANT:
-                    assert(false && "aliased VGF resources must not be constants");
-                    return nullptr;
-                }
-            }
-            assert(aliasIt != aliasedResources.end() && "failed to create aliased VGF resource");
-            return aliasIt->second;
-        };
-
-        // First: Resolve sequence input resources' bindings
-        std::vector<BindingSlotRef> sequenceInputBindings = {};
-        for (auto operand : sequenceOp.getArguments()) {
-            sequenceOp.walk([&](vgf::SegmentOp segmentOp) {
-                const auto segmentType = segmentOp.getSegmentType();
-                auto segmentId = segmentOp->getAttrOfType<IntegerAttr>("segment_id").getUInt();
-                auto *runSegmentOp = segmentOp->getNextNode();
-
-                WalkResult segmentWalkResult;
-                if (segmentType == vgf::SegmentTypeEnum::COMPUTE) {
-                    segmentWalkResult = segmentOp.walk([&](vgf::ShaderPlaceholderOp shaderPlaceholderOp) {
-                        size_t ioIndex = 0;
-                        for (const auto &[inputBinding, inputDescriptorType, inputVkFormat, inputDescriptorSet, input] :
-                             llvm::zip(shaderPlaceholderOp.getInputBindings(),
-                                       shaderPlaceholderOp.getInputVkDescriptorTypes(),
-                                       shaderPlaceholderOp.getInputVkFormats(),
-                                       shaderPlaceholderOp.getInputDescriptorSets(), runSegmentOp->getOperands())) {
-                            if (input == operand &&
-                                mapOperandsAndBindingRef.find(input) == mapOperandsAndBindingRef.end()) {
-                                const auto descriptorType =
-                                    NameToDescriptorType(llvm::cast<StringAttr>(inputDescriptorType).str());
-                                const ShapedType type = llvm::dyn_cast<ShapedType>(input.getType());
-                                const auto bindingIndex = operand.getArgNumber();
-                                const auto samplerConfigAttr =
-                                    getSamplerConfig(shaderPlaceholderOp.getInputSamplerConfigsAttr(), ioIndex);
-                                auto resourceRef =
-                                    std::make_shared<ResourceRef>(_VGFBuilder->getEncoder()->AddInputResource(
-                                        descriptorType, NameToFormatType(llvm::cast<StringAttr>(inputVkFormat).str()),
-                                        type.getShape(), {}));
-
-                                if (samplerConfigAttr && !samplerConfigAttr.empty()) {
-                                    const auto samplerConfig = getSamplerConfigValues(
-                                        shaderPlaceholderOp.getInputSamplerConfigsAttr(), ioIndex);
-                                    _VGFBuilder->getEncoder()->AddSamplerConfig(
-                                        *resourceRef, samplerConfig.minFilter, samplerConfig.magFilter,
-                                        samplerConfig.addressModeU, samplerConfig.addressModeV,
-                                        samplerConfig.borderColor);
-                                }
-
-                                auto bindingSlotRef = std::make_shared<BindingSlotRef>(
-                                    _VGFBuilder->getEncoder()->AddBindingSlot(bindingIndex, *resourceRef));
-
-                                rememberOperandResource(input, descriptorType, bindingIndex, resourceRef,
-                                                        bindingSlotRef);
-                                sequenceInputBindings.push_back(*bindingSlotRef);
-                                mapSegmentInputBindings[segmentId].push_back(*bindingSlotRef);
-                                addBindingToDescriptorSet(
-                                    segmentId, inputDescriptorSet,
-                                    getDescriptorSetBinding(input, static_cast<uint32_t>(inputBinding)));
-                            }
-                            ++ioIndex;
-                        }
-
-                        return WalkResult::advance();
-                    });
-                } else if (segmentType == vgf::SegmentTypeEnum::GRAPH) {
-                    segmentWalkResult = segmentOp.walk([&](spirv::ModuleOp spirvModuleOp) {
-                        WalkResult spirvModuleWalkResult = spirvModuleOp.walk([&](spirv::GraphARMOp) {
-                            for (const auto &[inputIdx, input] : llvm::enumerate(runSegmentOp->getOperands())) {
-                                if (input == operand &&
-                                    mapOperandsAndBindingRef.find(input) == mapOperandsAndBindingRef.end()) {
-                                    VGFBuilder::VkFormat vkFormat;
-                                    const ShapedType type = llvm::dyn_cast<ShapedType>(input.getType());
-                                    const auto bindingIndex = operand.getArgNumber();
-
-                                    if (_VGFBuilder
-                                            ->mlirTypeToVkFormat(
-                                                type.getElementType(), vkFormat,
-                                                sequenceOp
-                                                    .getArgAttrOfType<BoolAttr>(static_cast<uint32_t>(inputIdx),
-                                                                                "mlsdk.unsigned_input_output")
-                                                    .getValue())
-                                            .failed()) {
-                                        llvm::errs() << "Unsupported type for input at index " << inputIdx
-                                                     << " in segment " << segmentOp.getSymName().str() << "\n";
-                                        return WalkResult::interrupt();
-                                    }
-
-                                    auto resourceRef = _VGFBuilder->getEncoder()->AddInputResource(
-                                        DESCRIPTOR_TYPE_TENSOR_ARM, static_cast<FormatType>(vkFormat), type.getShape(),
-                                        {});
-
-                                    auto bindingSlotRef = std::make_shared<BindingSlotRef>(
-                                        _VGFBuilder->getEncoder()->AddBindingSlot(bindingIndex, resourceRef));
-
-                                    rememberOperandResource(input, DESCRIPTOR_TYPE_TENSOR_ARM, bindingIndex,
-                                                            std::make_shared<ResourceRef>(resourceRef), bindingSlotRef);
-                                    sequenceInputBindings.push_back(*bindingSlotRef);
-                                    mapSegmentInputBindings[segmentId].push_back(*bindingSlotRef);
-                                }
-                            }
-
-                            return WalkResult::advance();
-                        });
-                        return spirvModuleWalkResult;
-                    });
-                } else {
-                    // Segments can either be of Graph or Compute types
-                    llvm::errs() << "Invalid segment type in sequence module\n";
-                    return WalkResult::interrupt();
-                }
-                return segmentWalkResult;
-            });
+        detail::ResourcePlanner resourcePlanner(sequenceOp);
+        if (resourcePlanner.buildPlan().failed()) {
+            return failure();
         }
-
-        if (sequenceInputBindings.size() < sequenceOp.getNumArguments()) {
-            llvm::errs() << "Warning: Sequence module contains unused arguments\n";
-        }
-
-        // Second: Resolve sequence intermediate resources' bindings
-        auto bindingId = sequenceOp.getNumArguments();
-        WalkResult sequenceWalkResult = sequenceOp.walk([&](vgf::SegmentOp segmentOp) {
-            const auto segmentType = segmentOp.getSegmentType();
-            auto segmentId = segmentOp->getAttrOfType<IntegerAttr>("segment_id").getUInt();
-            auto *runSegmentOp = segmentOp->getNextNode();
-
-            WalkResult segmentWalkResult;
-            std::vector<BindingSlotRef> segmentInputBindings = {};
-            if (segmentType == vgf::SegmentTypeEnum::COMPUTE) {
-                segmentWalkResult = segmentOp.walk([&](vgf::ShaderPlaceholderOp shaderPlaceholderOp) {
-                    size_t ioIndex = 0;
-                    for (const auto &[inputBinding, inputDescriptorType, inputVkFormat, inputDescriptorSet, input] :
-                         llvm::zip(shaderPlaceholderOp.getInputBindings(),
-                                   shaderPlaceholderOp.getInputVkDescriptorTypes(),
-                                   shaderPlaceholderOp.getInputVkFormats(),
-                                   shaderPlaceholderOp.getInputDescriptorSets(), runSegmentOp->getOperands())) {
-                        if (!isSequenceInputOperand(input)) {
-                            auto it = mapOperandsAndBindingRef.find(input);
-                            const auto descriptorType =
-                                NameToDescriptorType(llvm::cast<StringAttr>(inputDescriptorType).str());
-                            if (it == mapOperandsAndBindingRef.end()) {
-                                // TODO: Revisit the need for conversion to ShapedType
-                                const ShapedType type = convertShapedType(input.getType());
-                                const auto bindingIndex = bindingId++;
-                                const auto samplerConfigAttr =
-                                    getSamplerConfig(shaderPlaceholderOp.getInputSamplerConfigsAttr(), ioIndex);
-
-                                auto resourceRef =
-                                    std::make_shared<ResourceRef>(_VGFBuilder->getEncoder()->AddIntermediateResource(
-                                        descriptorType, NameToFormatType(llvm::cast<StringAttr>(inputVkFormat).str()),
-                                        type.getShape(), {}));
-
-                                if (samplerConfigAttr && !samplerConfigAttr.empty()) {
-                                    const auto samplerConfig = getSamplerConfigValues(
-                                        shaderPlaceholderOp.getInputSamplerConfigsAttr(), ioIndex);
-                                    _VGFBuilder->getEncoder()->AddSamplerConfig(
-                                        *resourceRef, samplerConfig.minFilter, samplerConfig.magFilter,
-                                        samplerConfig.addressModeU, samplerConfig.addressModeV,
-                                        samplerConfig.borderColor);
-                                }
-
-                                auto bindingSlotRef = std::make_shared<BindingSlotRef>(
-                                    _VGFBuilder->getEncoder()->AddBindingSlot(bindingIndex, *resourceRef));
-
-                                rememberOperandResource(input, descriptorType, bindingIndex, resourceRef,
-                                                        bindingSlotRef);
-                                mapSegmentInputBindings[segmentId].push_back(*bindingSlotRef);
-                                addBindingToDescriptorSet(
-                                    segmentId, inputDescriptorSet,
-                                    getDescriptorSetBinding(input, static_cast<uint32_t>(inputBinding)));
-                            } else {
-                                auto descriptorTypeIt = mapOperandsAndDescriptorType.find(input);
-                                auto bindingIndexIt = mapOperandsAndBindingIndex.find(input);
-                                assert(descriptorTypeIt != mapOperandsAndDescriptorType.end());
-                                assert(bindingIndexIt != mapOperandsAndBindingIndex.end());
-                                if (descriptorTypeIt->second != descriptorType) {
-                                    // Reuse the same logical value binding, but expose the storage through a second
-                                    // MRT entry so runtimes can see the buffer-vs-tensor view change.
-                                    const ShapedType type = convertShapedType(input.getType());
-                                    auto aliasResourceRef = getOrCreateAliasedResource(
-                                        input, ResourceCategory::INTERMEDIATE, descriptorType,
-                                        NameToFormatType(llvm::cast<StringAttr>(inputVkFormat).str()), type);
-                                    auto aliasBindingSlotRef = _VGFBuilder->getEncoder()->AddBindingSlot(
-                                        bindingIndexIt->second, *aliasResourceRef);
-                                    mapSegmentInputBindings[segmentId].push_back(aliasBindingSlotRef);
-                                    addBindingToDescriptorSet(
-                                        segmentId, inputDescriptorSet,
-                                        _VGFBuilder->getEncoder()->AddBindingSlot(static_cast<uint32_t>(inputBinding),
-                                                                                  *aliasResourceRef));
-                                } else {
-                                    mapSegmentInputBindings[segmentId].push_back(*(it->second));
-                                    addBindingToDescriptorSet(
-                                        segmentId, inputDescriptorSet,
-                                        getDescriptorSetBinding(input, static_cast<uint32_t>(inputBinding)));
-                                }
-                            }
-                        }
-                        ++ioIndex;
-                    }
-
-                    ioIndex = 0;
-                    for (const auto &[outputBinding, outputDescriptorType, outputVkFormat, outputDescriptorSet,
-                                      result] :
-                         llvm::zip(shaderPlaceholderOp.getOutputBindings(),
-                                   shaderPlaceholderOp.getOutputVkDescriptorTypes(),
-                                   shaderPlaceholderOp.getOutputVkFormats(),
-                                   shaderPlaceholderOp.getOutputDescriptorSets(), runSegmentOp->getResults())) {
-                        if (!isSequenceOutputOperand(result)) {
-                            auto it = mapOperandsAndBindingRef.find(result);
-                            const auto descriptorType =
-                                NameToDescriptorType(llvm::cast<StringAttr>(outputDescriptorType).str());
-                            if (it == mapOperandsAndBindingRef.end()) {
-                                // TODO: Revisit the need for conversion to ShapedType
-                                const ShapedType type = convertShapedType(result.getType());
-                                const auto bindingIndex = bindingId++;
-                                const auto samplerConfigAttr =
-                                    getSamplerConfig(shaderPlaceholderOp.getOutputSamplerConfigsAttr(), ioIndex);
-
-                                auto resourceRef =
-                                    std::make_shared<ResourceRef>(_VGFBuilder->getEncoder()->AddIntermediateResource(
-                                        descriptorType, NameToFormatType(llvm::cast<StringAttr>(outputVkFormat).str()),
-                                        type.getShape(), {}));
-
-                                if (samplerConfigAttr && !samplerConfigAttr.empty()) {
-                                    const auto samplerConfig = getSamplerConfigValues(
-                                        shaderPlaceholderOp.getOutputSamplerConfigsAttr(), ioIndex);
-                                    _VGFBuilder->getEncoder()->AddSamplerConfig(
-                                        *resourceRef, samplerConfig.minFilter, samplerConfig.magFilter,
-                                        samplerConfig.addressModeU, samplerConfig.addressModeV,
-                                        samplerConfig.borderColor);
-                                }
-
-                                auto bindingSlotRef = std::make_shared<BindingSlotRef>(
-                                    _VGFBuilder->getEncoder()->AddBindingSlot(bindingIndex, *resourceRef));
-
-                                rememberOperandResource(result, descriptorType, bindingIndex, resourceRef,
-                                                        bindingSlotRef);
-                                mapSegmentOutputBindings[segmentId].push_back(*bindingSlotRef);
-                                addBindingToDescriptorSet(
-                                    segmentId, outputDescriptorSet,
-                                    getDescriptorSetBinding(result, static_cast<uint32_t>(outputBinding)));
-                            } else {
-                                mapSegmentOutputBindings[segmentId].push_back(*(it->second));
-                                addBindingToDescriptorSet(
-                                    segmentId, outputDescriptorSet,
-                                    getDescriptorSetBinding(result, static_cast<uint32_t>(outputBinding)));
-                            }
-                        }
-                        ++ioIndex;
-                    }
-                    return WalkResult::advance();
-                });
-            } else if (segmentType == vgf::SegmentTypeEnum::GRAPH) {
-                segmentWalkResult = segmentOp.walk([&](spirv::ModuleOp spirvModuleOp) {
-                    WalkResult spirvModuleWalkResult = spirvModuleOp.walk([&](spirv::GraphARMOp) {
-                        for (const auto &input : runSegmentOp->getOperands()) {
-                            if (!isSequenceInputOperand(input)) {
-                                auto it = mapOperandsAndBindingRef.find(input);
-                                if (it == mapOperandsAndBindingRef.end()) {
-                                    VGFBuilder::VkFormat vkFormat;
-                                    // TODO: Revisit the need for conversion to ShapedType
-                                    const ShapedType type = convertShapedType(input.getType());
-                                    if (_VGFBuilder->mlirTypeToVkFormat(type.getElementType(), vkFormat, false)
-                                            .failed()) {
-                                        llvm::errs() << "Unsupported type for input in segment "
-                                                     << segmentOp.getSymName().str() << "\n";
-                                        return WalkResult::interrupt();
-                                    }
-
-                                    auto resourceRef = _VGFBuilder->getEncoder()->AddIntermediateResource(
-                                        DESCRIPTOR_TYPE_TENSOR_ARM, static_cast<FormatType>(vkFormat), type.getShape(),
-                                        {});
-
-                                    const auto bindingIndex = bindingId++;
-                                    auto bindingSlotRef = std::make_shared<BindingSlotRef>(
-                                        _VGFBuilder->getEncoder()->AddBindingSlot(bindingIndex, resourceRef));
-
-                                    rememberOperandResource(input, DESCRIPTOR_TYPE_TENSOR_ARM, bindingIndex,
-                                                            std::make_shared<ResourceRef>(resourceRef), bindingSlotRef);
-                                    mapSegmentInputBindings[segmentId].push_back(*bindingSlotRef);
-                                } else {
-                                    mapSegmentInputBindings[segmentId].push_back(*(it->second));
-                                }
-                            }
-                        }
-
-                        for (const auto &result : runSegmentOp->getResults()) {
-                            if (!isSequenceOutputOperand(result)) {
-                                auto it = mapOperandsAndBindingRef.find(result);
-                                if (it == mapOperandsAndBindingRef.end()) {
-                                    VGFBuilder::VkFormat vkFormat;
-                                    // TODO: Revisit the need for conversion to ShapedType
-                                    const ShapedType type = convertShapedType(result.getType());
-                                    if (_VGFBuilder->mlirTypeToVkFormat(type.getElementType(), vkFormat, false)
-                                            .failed()) {
-                                        llvm::errs() << "Unsupported type for result in segment "
-                                                     << segmentOp.getSymName().str() << "\n";
-                                        return WalkResult::interrupt();
-                                    }
-
-                                    auto resourceRef = std::make_shared<ResourceRef>(
-                                        _VGFBuilder->getEncoder()->AddIntermediateResource(
-                                            DESCRIPTOR_TYPE_TENSOR_ARM, static_cast<FormatType>(vkFormat),
-                                            type.getShape(), {}));
-
-                                    const auto bindingIndex = bindingId++;
-                                    auto bindingSlotRef = std::make_shared<BindingSlotRef>(
-                                        _VGFBuilder->getEncoder()->AddBindingSlot(bindingIndex, *resourceRef));
-
-                                    rememberOperandResource(result, DESCRIPTOR_TYPE_TENSOR_ARM, bindingIndex,
-                                                            resourceRef, bindingSlotRef);
-                                    mapSegmentOutputBindings[segmentId].push_back(*bindingSlotRef);
-                                } else {
-                                    mapSegmentOutputBindings[segmentId].push_back(*(it->second));
-                                }
-                            }
-                        }
-                        return WalkResult::advance();
-                    });
-                    return spirvModuleWalkResult;
-                });
-            } else {
-                // Segments can either be of Graph or Compute types
-                return WalkResult::interrupt();
-            }
-            return segmentWalkResult;
-        });
-
-        // Third: Resolve sequence output resources' bindings
-        std::vector<BindingSlotRef> sequenceOutputBindings = {};
-        for (auto operand : sequenceOutputOp->getOperands()) {
-            sequenceOp.walk([&](vgf::SegmentOp segmentOp) {
-                const auto segmentType = segmentOp.getSegmentType();
-                auto segmentId = segmentOp->getAttrOfType<IntegerAttr>("segment_id").getUInt();
-                auto *runSegmentOp = segmentOp->getNextNode();
-
-                WalkResult segmentWalkResult;
-                if (segmentType == vgf::SegmentTypeEnum::COMPUTE) {
-                    segmentWalkResult = segmentOp.walk([&](vgf::ShaderPlaceholderOp shaderPlaceholderOp) {
-                        size_t ioIndex = 0;
-                        for (const auto &[outputBinding, outputDescriptorType, outputVkFormat, outputDescriptorSet,
-                                          result] :
-                             llvm::zip(shaderPlaceholderOp.getOutputBindings(),
-                                       shaderPlaceholderOp.getOutputVkDescriptorTypes(),
-                                       shaderPlaceholderOp.getOutputVkFormats(),
-                                       shaderPlaceholderOp.getOutputDescriptorSets(), runSegmentOp->getResults())) {
-
-                            if (result == operand &&
-                                mapOperandsAndBindingRef.find(result) == mapOperandsAndBindingRef.end()) {
-                                const auto descriptorType =
-                                    NameToDescriptorType(llvm::cast<StringAttr>(outputDescriptorType).str());
-                                const ShapedType type = llvm::dyn_cast<ShapedType>(result.getType());
-                                const auto bindingIndex = bindingId++;
-                                const auto samplerConfigAttr =
-                                    getSamplerConfig(shaderPlaceholderOp.getOutputSamplerConfigsAttr(), ioIndex);
-
-                                auto resourceRef =
-                                    std::make_shared<ResourceRef>(_VGFBuilder->getEncoder()->AddOutputResource(
-                                        descriptorType, NameToFormatType(llvm::cast<StringAttr>(outputVkFormat).str()),
-                                        type.getShape(), {}));
-
-                                if (samplerConfigAttr && !samplerConfigAttr.empty()) {
-                                    const auto samplerConfig = getSamplerConfigValues(
-                                        shaderPlaceholderOp.getOutputSamplerConfigsAttr(), ioIndex);
-                                    _VGFBuilder->getEncoder()->AddSamplerConfig(
-                                        *resourceRef, samplerConfig.minFilter, samplerConfig.magFilter,
-                                        samplerConfig.addressModeU, samplerConfig.addressModeV,
-                                        samplerConfig.borderColor);
-                                }
-
-                                auto bindingSlotRef = std::make_shared<BindingSlotRef>(
-                                    _VGFBuilder->getEncoder()->AddBindingSlot(bindingIndex, *resourceRef));
-
-                                rememberOperandResource(result, descriptorType, bindingIndex, resourceRef,
-                                                        bindingSlotRef);
-                                sequenceOutputBindings.push_back(*bindingSlotRef);
-                                mapSegmentOutputBindings[segmentId].push_back(*bindingSlotRef);
-                                addBindingToDescriptorSet(
-                                    segmentId, outputDescriptorSet,
-                                    getDescriptorSetBinding(result, static_cast<uint32_t>(outputBinding)));
-                            }
-                            ++ioIndex;
-                        }
-
-                        return WalkResult::advance();
-                    });
-                } else if (segmentType == vgf::SegmentTypeEnum::GRAPH) {
-                    segmentWalkResult = segmentOp.walk([&](spirv::ModuleOp spirvModuleOp) {
-                        WalkResult spirvModuleWalkResult = spirvModuleOp.walk([&](spirv::GraphARMOp) {
-                            for (const auto &[resIdx, result] : llvm::enumerate(runSegmentOp->getResults())) {
-                                if (result == operand &&
-                                    mapOperandsAndBindingRef.find(result) == mapOperandsAndBindingRef.end()) {
-                                    VGFBuilder::VkFormat vkFormat;
-                                    const ShapedType type = llvm::dyn_cast<ShapedType>(result.getType());
-
-                                    if (_VGFBuilder
-                                            ->mlirTypeToVkFormat(
-                                                type.getElementType(), vkFormat,
-                                                sequenceOp
-                                                    .getResultAttrOfType<BoolAttr>(static_cast<uint32_t>(resIdx),
-                                                                                   "mlsdk.unsigned_input_output")
-                                                    .getValue())
-                                            .failed()) {
-                                        llvm::errs() << "Unsupported type for result at index " << resIdx
-                                                     << " in segment " << segmentOp.getSymName().str() << "\n";
-                                        return WalkResult::interrupt();
-                                    }
-
-                                    auto resourceRef = _VGFBuilder->getEncoder()->AddOutputResource(
-                                        DESCRIPTOR_TYPE_TENSOR_ARM, static_cast<FormatType>(vkFormat), type.getShape(),
-                                        {});
-
-                                    const auto bindingIndex = bindingId++;
-                                    auto bindingSlotRef = std::make_shared<BindingSlotRef>(
-                                        _VGFBuilder->getEncoder()->AddBindingSlot(bindingIndex, resourceRef));
-
-                                    rememberOperandResource(result, DESCRIPTOR_TYPE_TENSOR_ARM, bindingIndex,
-                                                            std::make_shared<ResourceRef>(resourceRef), bindingSlotRef);
-                                    sequenceOutputBindings.push_back(*bindingSlotRef);
-                                    mapSegmentOutputBindings[segmentId].push_back(*bindingSlotRef);
-                                }
-                            }
-
-                            return WalkResult::advance();
-                        });
-                        return spirvModuleWalkResult;
-                    });
-                } else {
-                    // Segments can either be of Graph or Compute types
-                    return WalkResult::interrupt();
-                }
-                return segmentWalkResult;
-            });
-        }
+        ResourcePlanEncoder resourcePlanEncoder(resourcePlanner.getPlan(), *_VGFBuilder);
+        const auto &encodedResourcePlan = resourcePlanEncoder.encode();
 
         uint32_t computeSegmentId = 0;
         uint32_t graphSegmentId = 0;
 
-        sequenceWalkResult = sequenceOp.walk([&](vgf::SegmentOp segmentOp) {
+        WalkResult sequenceWalkResult = sequenceOp.walk([&](vgf::SegmentOp segmentOp) {
             const auto segmentName = segmentOp.getSymName();
             const auto segmentType = segmentOp.getSegmentType();
             auto segmentId = segmentOp->getAttrOfType<IntegerAttr>("segment_id").getUInt();
+            const auto &segmentInputBindings = encodedResourcePlan.getSegmentInputBindings(segmentId);
+            const auto &segmentOutputBindings = encodedResourcePlan.getSegmentOutputBindings(segmentId);
 
             WalkResult segmentWalkResult;
             std::vector<BindingSlotRef> segmentAllBindings = {};
@@ -736,11 +143,17 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
                                                                     shaderPlaceholderOp.getEntryPointAttr().str());
                     }();
 
-                    std::vector<DescriptorSetInfoRef> descriptorSetInfos = {};
-                    for (const auto &[descriptorSetIndex, bindings] : mapSegmentDescriptorSetBindings[segmentId]) {
-                        descriptorSetInfos.push_back(
-                            _VGFBuilder->getEncoder()->AddDescriptorSetInfo(bindings, descriptorSetIndex));
-                    }
+                    const auto descriptorSetInfos = [&]() {
+                        std::vector<DescriptorSetInfoRef> descriptorSetInfos = {};
+                        auto descriptorSetBindingsIt = encodedResourcePlan.segmentDescriptorSetBindings.find(segmentId);
+                        if (descriptorSetBindingsIt != encodedResourcePlan.segmentDescriptorSetBindings.end()) {
+                            for (const auto &[descriptorSetIndex, bindings] : descriptorSetBindingsIt->second) {
+                                descriptorSetInfos.push_back(
+                                    _VGFBuilder->getEncoder()->AddDescriptorSetInfo(bindings, descriptorSetIndex));
+                            }
+                        }
+                        return descriptorSetInfos;
+                    }();
 
                     auto workgroupSizes = ArrayRef<int64_t>(shaderPlaceholderOp.getWorkgroupSizesAttr());
                     assert(workgroupSizes.size() == 3);
@@ -750,8 +163,7 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
 
                     _VGFBuilder->getEncoder()->AddSegmentInfo(
                         computeModuleRef, "compute_segment_" + std::to_string(computeSegmentId++), descriptorSetInfos,
-                        mapSegmentInputBindings[segmentId], mapSegmentOutputBindings[segmentId],
-                        _VGFBuilder->getConstantRefs(), dispatchShape);
+                        segmentInputBindings, segmentOutputBindings, _VGFBuilder->getConstantRefs(), dispatchShape);
 
                     return WalkResult::advance();
                 });
@@ -775,18 +187,17 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
                                                              std::vector<uint32_t>(binary.begin(), binary.end()));
 
                     WalkResult spirvModuleWalkResult = spirvModuleOp.walk([&](spirv::GraphARMOp) {
-                        std::copy(mapSegmentInputBindings[segmentId].cbegin(),
-                                  mapSegmentInputBindings[segmentId].cend(), std::back_inserter(segmentAllBindings));
-                        std::copy(mapSegmentOutputBindings[segmentId].cbegin(),
-                                  mapSegmentOutputBindings[segmentId].cend(), std::back_inserter(segmentAllBindings));
+                        std::copy(segmentInputBindings.cbegin(), segmentInputBindings.cend(),
+                                  std::back_inserter(segmentAllBindings));
+                        std::copy(segmentOutputBindings.cbegin(), segmentOutputBindings.cend(),
+                                  std::back_inserter(segmentAllBindings));
 
                         const DescriptorSetInfoRef descSetInfo =
                             _VGFBuilder->getEncoder()->AddDescriptorSetInfo(segmentAllBindings);
 
                         _VGFBuilder->getEncoder()->AddSegmentInfo(
                             graphModuleRef, "graph_segment_" + std::to_string(graphSegmentId++), {descSetInfo},
-                            mapSegmentInputBindings[segmentId], mapSegmentOutputBindings[segmentId],
-                            _VGFBuilder->getConstantRefs());
+                            segmentInputBindings, segmentOutputBindings, _VGFBuilder->getConstantRefs());
 
                         return WalkResult::advance();
                     });
@@ -803,8 +214,9 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
             return failure();
         }
 
-        _VGFBuilder->getEncoder()->AddModelSequenceInputsOutputs(sequenceInputBindings, inputNames,
-                                                                 sequenceOutputBindings, outputNames);
+        _VGFBuilder->getEncoder()->AddModelSequenceInputsOutputs(encodedResourcePlan.sequenceInputBindings, inputNames,
+                                                                 encodedResourcePlan.sequenceOutputBindings,
+                                                                 outputNames);
         return success();
     }
 

--- a/test/test_model_converter_custom_v100.py
+++ b/test/test_model_converter_custom_v100.py
@@ -15,6 +15,28 @@ VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER = 1
 VK_DESCRIPTOR_TYPE_STORAGE_IMAGE = 3
 VK_DESCRIPTOR_TYPE_STORAGE_BUFFER = 7
 VK_DESCRIPTOR_TYPE_TENSOR_ARM = 1000460000
+VK_FILTER_NEAREST = 0
+VK_FILTER_LINEAR = 1
+VK_SAMPLER_ADDRESS_MODE_REPEAT = 0
+VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER = 3
+VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK = 0
+VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK = 2
+
+LINEAR_BORDER_SAMPLER_CONFIG = {
+    "min_filter": "VK_FILTER_LINEAR",
+    "mag_filter": "VK_FILTER_LINEAR",
+    "address_mode_u": "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER",
+    "address_mode_v": "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER",
+    "border_color": "VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK",
+}
+
+NEAREST_REPEAT_SAMPLER_CONFIG = {
+    "min_filter": "VK_FILTER_NEAREST",
+    "mag_filter": "VK_FILTER_NEAREST",
+    "address_mode_u": "VK_SAMPLER_ADDRESS_MODE_REPEAT",
+    "address_mode_v": "VK_SAMPLER_ADDRESS_MODE_REPEAT",
+    "border_color": "VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK",
+}
 
 SHADER_CASES = [
     {
@@ -84,6 +106,8 @@ def custom_shader_attrs(
     output_descriptor_sets=None,
     input_vk_descriptor_types=None,
     output_vk_descriptor_types=None,
+    input_sampler_configs=None,
+    output_sampler_configs=None,
     tensor_type="TENSOR",
     extra_attrs=None,
 ):
@@ -95,6 +119,10 @@ def custom_shader_attrs(
     output_vk_descriptor_types = output_vk_descriptor_types or [
         "VK_DESCRIPTOR_TYPE_TENSOR_ARM"
     ] * len(output_bindings)
+    if input_sampler_configs is None:
+        input_sampler_configs = [None] * len(input_bindings)
+    if output_sampler_configs is None:
+        output_sampler_configs = [None] * len(output_bindings)
     implementation_attrs = {
         "entry_point": "main",
         "is_vkshader": True,
@@ -111,6 +139,10 @@ def custom_shader_attrs(
             input_vk_descriptor_types[index]
         )
         implementation_attrs[f"input_{index}_vkformat"] = vk_format
+        if input_sampler_configs[index] is not None:
+            implementation_attrs[f"input_{index}_sampler"] = input_sampler_configs[
+                index
+            ]
 
     for index, binding in enumerate(output_bindings):
         implementation_attrs[f"output_{index}_binding"] = binding
@@ -122,6 +154,10 @@ def custom_shader_attrs(
             output_vk_descriptor_types[index]
         )
         implementation_attrs[f"output_{index}_vkformat"] = vk_format
+        if output_sampler_configs[index] is not None:
+            implementation_attrs[f"output_{index}_sampler"] = output_sampler_configs[
+                index
+            ]
 
     if extra_attrs is not None:
         implementation_attrs.update(extra_attrs)
@@ -180,14 +216,30 @@ def custom_op(
     workgroup_sizes,
     input_vk_descriptor_types=None,
     output_vk_descriptor_types=None,
+    input_bindings=None,
+    output_bindings=None,
+    input_descriptor_sets=None,
+    output_descriptor_sets=None,
+    input_sampler_configs=None,
+    output_sampler_configs=None,
+    tensor_type_attr="TENSOR",
 ):
+    if input_bindings is None:
+        input_bindings = list(range(len(operands)))
+    if output_bindings is None:
+        output_bindings = [len(input_bindings)]
     implementation_attrs = custom_shader_attrs(
         vk_format=vk_format,
         workgroup_sizes=workgroup_sizes,
-        input_bindings=[0, 1],
-        output_bindings=[2],
+        input_bindings=input_bindings,
+        output_bindings=output_bindings,
+        input_descriptor_sets=input_descriptor_sets,
+        output_descriptor_sets=output_descriptor_sets,
         input_vk_descriptor_types=input_vk_descriptor_types,
         output_vk_descriptor_types=output_vk_descriptor_types,
+        input_sampler_configs=input_sampler_configs,
+        output_sampler_configs=output_sampler_configs,
+        tensor_type=tensor_type_attr,
         extra_attrs=shader_case["attrs"],
     )
     operands = ", ".join(operands)
@@ -195,6 +247,58 @@ def custom_op(
     return f"""
     {result} = tosa.custom {operands} {{domain_name = "com.arm.VulkanCustomShader", implementation_attrs = {implementation_attrs}, operator_name = "{operator_name}"}} : ({operand_types}) -> {result_type}
 """
+
+
+def binding_slots_by_binding(vgf, bindings_handle):
+    return {
+        vgf.sequence.getBindingSlotBinding(bindings_handle, binding_index): (
+            vgf.sequence.getBindingSlotMrtIndex(bindings_handle, binding_index)
+        )
+        for binding_index in range(vgf.sequence.getBindingsSize(bindings_handle))
+    }
+
+
+def find_resource_indices(
+    vgf, *, category=None, descriptor_type=None, alias_group=None
+):
+    indices = []
+    for resource_index in range(vgf.resources.size()):
+        if (
+            category is not None
+            and vgf.resources.getCategory(resource_index) != category
+        ):
+            continue
+        if (
+            descriptor_type is not None
+            and vgf.resources.getDescriptorType(resource_index) != descriptor_type
+        ):
+            continue
+        if (
+            alias_group is not None
+            and vgf.resources.getAliasGroupId(resource_index) != alias_group
+        ):
+            continue
+        indices.append(resource_index)
+    return indices
+
+
+def assert_sampler_config(
+    vgf,
+    resource_index,
+    *,
+    min_filter,
+    mag_filter,
+    address_mode_u,
+    address_mode_v,
+    border_color,
+):
+    sampler_handle = vgf.resources.getSamplerConfigHandle(resource_index)
+    assert sampler_handle is not None
+    assert vgf.resources.getSamplerConfigMinFilter(sampler_handle) == min_filter
+    assert vgf.resources.getSamplerConfigMagFilter(sampler_handle) == mag_filter
+    assert vgf.resources.getSamplerConfigAddressModeU(sampler_handle) == address_mode_u
+    assert vgf.resources.getSamplerConfigAddressModeV(sampler_handle) == address_mode_v
+    assert vgf.resources.getSamplerConfigBorderColor(sampler_handle) == border_color
 
 
 def custom_binding_mlir(input_descriptor_set, output_descriptor_set):
@@ -314,6 +418,122 @@ module {{
 {first_custom}
 {second_custom}
     return %1 : tensor<1x16x16x16xf32>
+  }}
+}}
+"""
+
+
+def shared_sequence_input_mlir(
+    first_input_descriptor_type,
+    second_input_descriptor_type,
+    *,
+    vk_format="VK_FORMAT_R32_SFLOAT",
+    tensor_type="tensor<1x16x16x16xf32>",
+    sampler_config=None,
+    sampler_configs=None,
+    shader_tensor_type="TENSOR",
+):
+    shader_case = SHADER_CASES[0]
+    if sampler_configs is None and sampler_config is not None:
+        sampler_configs = [sampler_config, sampler_config]
+    first_input_sampler_configs = (
+        [sampler_configs[0]] if sampler_configs is not None else None
+    )
+    second_input_sampler_configs = (
+        [sampler_configs[1]] if sampler_configs is not None else None
+    )
+    first_custom = custom_op(
+        "%0",
+        ["%arg0"],
+        [tensor_type],
+        tensor_type,
+        "test_shared_sequence_input_shader_0",
+        shader_case,
+        vk_format,
+        [16, 16, 1],
+        input_vk_descriptor_types=[first_input_descriptor_type],
+        input_bindings=[0],
+        output_bindings=[1],
+        input_sampler_configs=first_input_sampler_configs,
+        tensor_type_attr=shader_tensor_type,
+    )
+    second_custom = custom_op(
+        "%1",
+        ["%arg0"],
+        [tensor_type],
+        tensor_type,
+        "test_shared_sequence_input_shader_1",
+        shader_case,
+        vk_format,
+        [8, 8, 1],
+        input_vk_descriptor_types=[second_input_descriptor_type],
+        input_bindings=[0],
+        output_bindings=[1],
+        input_sampler_configs=second_input_sampler_configs,
+        tensor_type_attr=shader_tensor_type,
+    )
+
+    return f"""
+module {{
+  func.func @main(%arg0: {tensor_type} {{tf_saved_model.index_path = ["input_0"]}}) -> ({tensor_type} {{tf_saved_model.index_path = ["output_0"]}}) attributes {{tf.entry_function = {{inputs = "input_0", outputs = "output_0"}}, tf_saved_model.exported_names = ["serving_default"]}} {{
+{first_custom}
+{second_custom}
+    %2 = tosa.add %0, %1 : ({tensor_type}, {tensor_type}) -> {tensor_type}
+    return %2 : {tensor_type}
+  }}
+}}
+"""
+
+
+def input_passthrough_with_custom_mlir():
+    tensor_type = "tensor<1x16x16x16xf32>"
+    shader_case = SHADER_CASES[0]
+    custom = custom_op(
+        "%0",
+        ["%arg1"],
+        [tensor_type],
+        tensor_type,
+        "test_input_passthrough_shader",
+        shader_case,
+        "VK_FORMAT_R32_SFLOAT",
+        [16, 16, 1],
+        input_bindings=[0],
+        output_bindings=[1],
+    )
+
+    return f"""
+module {{
+  func.func @main(%arg0: {tensor_type} {{tf_saved_model.index_path = ["input_0"]}}, %arg1: {tensor_type} {{tf_saved_model.index_path = ["input_1"]}}) -> ({tensor_type} {{tf_saved_model.index_path = ["output_0"]}}, {tensor_type} {{tf_saved_model.index_path = ["output_1"]}}) attributes {{tf.entry_function = {{inputs = "input_0,input_1", outputs = "output_0,output_1"}}, tf_saved_model.exported_names = ["serving_default"]}} {{
+{custom}
+    return %arg0, %0 : {tensor_type}, {tensor_type}
+  }}
+}}
+"""
+
+
+def compute_output_to_graph_mlir(compute_output_descriptor_type):
+    tensor_type = "tensor<1x16x16x16xf32>"
+    shader_case = SHADER_CASES[0]
+    custom = custom_op(
+        "%0",
+        ["%arg0"],
+        [tensor_type],
+        tensor_type,
+        "test_compute_output_to_graph_shader",
+        shader_case,
+        "VK_FORMAT_R32_SFLOAT",
+        [16, 16, 1],
+        input_bindings=[0],
+        output_bindings=[1],
+        output_vk_descriptor_types=[compute_output_descriptor_type],
+    )
+
+    return f"""
+module {{
+  func.func @main(%arg0: {tensor_type} {{tf_saved_model.index_path = ["input_0"]}}) -> ({tensor_type} {{tf_saved_model.index_path = ["output_0"]}}) attributes {{tf.entry_function = {{inputs = "input_0", outputs = "output_0"}}, tf_saved_model.exported_names = ["serving_default"]}} {{
+{custom}
+    %1 = tosa.abs %0 : ({tensor_type}) -> {tensor_type}
+    return %1 : {tensor_type}
   }}
 }}
 """
@@ -509,6 +729,39 @@ def test_descriptor_type_change_creates_alias_group_for_intermediate(
         assert second_input_bindings == [(2, 2), (3, 4)]
 
 
+def test_image_buffer_descriptor_type_change_creates_alias_group_for_intermediate(
+    model_converter_exe_path,
+):
+    with converted_mlir(
+        model_converter_exe_path,
+        descriptor_type_aliasing_mlir(
+            "VK_DESCRIPTOR_TYPE_STORAGE_IMAGE",
+            "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER",
+        ),
+    ) as vgf:
+        intermediate_resources = find_resource_indices(
+            vgf, category=vgfpy.ResourceCategory.Intermediate
+        )
+        assert len(intermediate_resources) == 2
+
+        image_resource = find_resource_indices(
+            vgf,
+            category=vgfpy.ResourceCategory.Intermediate,
+            descriptor_type=VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+        )
+        buffer_resource = find_resource_indices(
+            vgf,
+            category=vgfpy.ResourceCategory.Intermediate,
+            descriptor_type=VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+        )
+        assert len(image_resource) == 1
+        assert len(buffer_resource) == 1
+
+        shared_alias_group = vgf.resources.getAliasGroupId(image_resource[0])
+        assert shared_alias_group is not None
+        assert vgf.resources.getAliasGroupId(buffer_resource[0]) == shared_alias_group
+
+
 def test_descriptor_type_match_does_not_create_alias_group(
     model_converter_exe_path,
 ):
@@ -541,6 +794,303 @@ def test_descriptor_type_match_does_not_create_alias_group(
             for binding_index in range(vgf.sequence.getBindingsSize(second_inputs))
         )
         assert second_input_bindings == [(2, 2), (3, 3)]
+
+
+def test_shared_sequence_input_is_bound_in_multiple_compute_segments(
+    model_converter_exe_path,
+):
+    with converted_mlir(
+        model_converter_exe_path,
+        shared_sequence_input_mlir(
+            "VK_DESCRIPTOR_TYPE_TENSOR_ARM",
+            "VK_DESCRIPTOR_TYPE_TENSOR_ARM",
+        ),
+    ) as vgf:
+        assert vgf.sequence.modelSequenceTableSize() == 3
+        assert vgf.sequence.getSegmentType(0) == vgfpy.ModuleType.Compute
+        assert vgf.sequence.getSegmentType(1) == vgfpy.ModuleType.Compute
+        assert (
+            len(find_resource_indices(vgf, category=vgfpy.ResourceCategory.Input)) == 1
+        )
+
+        first_inputs = binding_slots_by_binding(
+            vgf, vgf.sequence.getSegmentInputBindingSlotsHandle(0)
+        )
+        second_inputs = binding_slots_by_binding(
+            vgf, vgf.sequence.getSegmentInputBindingSlotsHandle(1)
+        )
+        assert first_inputs == {0: 0}
+        assert second_inputs == {0: 0}
+
+        first_descriptor_bindings = binding_slots_by_binding(
+            vgf, vgf.sequence.getDescriptorBindingSlotsHandle(0, 0)
+        )
+        second_descriptor_bindings = binding_slots_by_binding(
+            vgf, vgf.sequence.getDescriptorBindingSlotsHandle(1, 0)
+        )
+        assert first_descriptor_bindings[0] == 0
+        assert second_descriptor_bindings[0] == 0
+
+
+def test_shared_sequence_input_descriptor_type_change_creates_alias_group(
+    model_converter_exe_path,
+):
+    with converted_mlir(
+        model_converter_exe_path,
+        shared_sequence_input_mlir(
+            "VK_DESCRIPTOR_TYPE_TENSOR_ARM",
+            "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER",
+        ),
+    ) as vgf:
+        assert vgf.sequence.modelSequenceTableSize() == 3
+        assert (
+            len(find_resource_indices(vgf, category=vgfpy.ResourceCategory.Input)) == 2
+        )
+
+        first_inputs = binding_slots_by_binding(
+            vgf, vgf.sequence.getSegmentInputBindingSlotsHandle(0)
+        )
+        second_inputs = binding_slots_by_binding(
+            vgf, vgf.sequence.getSegmentInputBindingSlotsHandle(1)
+        )
+        first_input_resource = first_inputs[0]
+        second_input_resource = second_inputs[0]
+        assert first_input_resource != second_input_resource
+        assert (
+            vgf.resources.getDescriptorType(first_input_resource)
+            == VK_DESCRIPTOR_TYPE_TENSOR_ARM
+        )
+        assert (
+            vgf.resources.getDescriptorType(second_input_resource)
+            == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER
+        )
+
+        first_descriptor_bindings = binding_slots_by_binding(
+            vgf, vgf.sequence.getDescriptorBindingSlotsHandle(0, 0)
+        )
+        second_descriptor_bindings = binding_slots_by_binding(
+            vgf, vgf.sequence.getDescriptorBindingSlotsHandle(1, 0)
+        )
+        assert first_descriptor_bindings[0] == first_input_resource
+        assert second_descriptor_bindings[0] == second_input_resource
+
+        shared_alias_group = vgf.resources.getAliasGroupId(first_input_resource)
+        assert shared_alias_group is not None
+        assert (
+            vgf.resources.getAliasGroupId(second_input_resource) == shared_alias_group
+        )
+
+        for resource_index in range(vgf.resources.size()):
+            if resource_index not in {first_input_resource, second_input_resource}:
+                assert vgf.resources.getAliasGroupId(resource_index) is None
+
+
+def test_shared_sequence_input_descriptor_type_match_does_not_create_alias_group(
+    model_converter_exe_path,
+):
+    with converted_mlir(
+        model_converter_exe_path,
+        shared_sequence_input_mlir(
+            "VK_DESCRIPTOR_TYPE_TENSOR_ARM",
+            "VK_DESCRIPTOR_TYPE_TENSOR_ARM",
+        ),
+    ) as vgf:
+        assert (
+            len(find_resource_indices(vgf, category=vgfpy.ResourceCategory.Input)) == 1
+        )
+
+        first_inputs = binding_slots_by_binding(
+            vgf, vgf.sequence.getSegmentInputBindingSlotsHandle(0)
+        )
+        second_inputs = binding_slots_by_binding(
+            vgf, vgf.sequence.getSegmentInputBindingSlotsHandle(1)
+        )
+        assert first_inputs == {0: 0}
+        assert second_inputs == {0: 0}
+
+        first_descriptor_bindings = binding_slots_by_binding(
+            vgf, vgf.sequence.getDescriptorBindingSlotsHandle(0, 0)
+        )
+        second_descriptor_bindings = binding_slots_by_binding(
+            vgf, vgf.sequence.getDescriptorBindingSlotsHandle(1, 0)
+        )
+        assert first_descriptor_bindings[0] == 0
+        assert second_descriptor_bindings[0] == 0
+
+        for resource_index in range(vgf.resources.size()):
+            assert vgf.resources.getAliasGroupId(resource_index) is None
+
+
+def test_compute_output_consumed_by_graph_segment_creates_tensor_arm_alias(
+    model_converter_exe_path,
+):
+    with converted_mlir(
+        model_converter_exe_path,
+        compute_output_to_graph_mlir("VK_DESCRIPTOR_TYPE_STORAGE_BUFFER"),
+    ) as vgf:
+        assert vgf.sequence.modelSequenceTableSize() == 2
+        assert vgf.sequence.getSegmentType(0) == vgfpy.ModuleType.Compute
+        assert vgf.sequence.getSegmentType(1) == vgfpy.ModuleType.Graph
+        assert (
+            len(
+                find_resource_indices(vgf, category=vgfpy.ResourceCategory.Intermediate)
+            )
+            == 2
+        )
+
+        compute_outputs = binding_slots_by_binding(
+            vgf, vgf.sequence.getSegmentOutputBindingSlotsHandle(0)
+        )
+        graph_inputs = binding_slots_by_binding(
+            vgf, vgf.sequence.getSegmentInputBindingSlotsHandle(1)
+        )
+        compute_output_resource = compute_outputs[1]
+        graph_input_resource = graph_inputs[1]
+        assert compute_output_resource != graph_input_resource
+        assert (
+            vgf.resources.getDescriptorType(compute_output_resource)
+            == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER
+        )
+        assert (
+            vgf.resources.getDescriptorType(graph_input_resource)
+            == VK_DESCRIPTOR_TYPE_TENSOR_ARM
+        )
+
+        shared_alias_group = vgf.resources.getAliasGroupId(compute_output_resource)
+        assert shared_alias_group is not None
+        assert vgf.resources.getAliasGroupId(graph_input_resource) == shared_alias_group
+
+
+def test_descriptor_type_aliasing_preserves_sampler_config(
+    model_converter_exe_path,
+):
+    with converted_mlir(
+        model_converter_exe_path,
+        shared_sequence_input_mlir(
+            "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER",
+            "VK_DESCRIPTOR_TYPE_STORAGE_IMAGE",
+            vk_format="VK_FORMAT_R32G32B32A32_SFLOAT",
+            tensor_type="tensor<1x8x8x4xf32>",
+            sampler_config=LINEAR_BORDER_SAMPLER_CONFIG,
+            shader_tensor_type="Image",
+        ),
+    ) as vgf:
+        first_inputs = binding_slots_by_binding(
+            vgf, vgf.sequence.getSegmentInputBindingSlotsHandle(0)
+        )
+        second_inputs = binding_slots_by_binding(
+            vgf, vgf.sequence.getSegmentInputBindingSlotsHandle(1)
+        )
+        first_input_resource = first_inputs[0]
+        second_input_resource = second_inputs[0]
+        assert (
+            vgf.resources.getDescriptorType(first_input_resource)
+            == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER
+        )
+        assert (
+            vgf.resources.getDescriptorType(second_input_resource)
+            == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE
+        )
+
+        shared_alias_group = vgf.resources.getAliasGroupId(first_input_resource)
+        assert shared_alias_group is not None
+        assert (
+            vgf.resources.getAliasGroupId(second_input_resource) == shared_alias_group
+        )
+
+        assert_sampler_config(
+            vgf,
+            second_input_resource,
+            min_filter=VK_FILTER_LINEAR,
+            mag_filter=VK_FILTER_LINEAR,
+            address_mode_u=VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER,
+            address_mode_v=VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER,
+            border_color=VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK,
+        )
+
+
+def test_shared_sequence_input_with_different_samplers_creates_alias_resources(
+    model_converter_exe_path,
+):
+    with converted_mlir(
+        model_converter_exe_path,
+        shared_sequence_input_mlir(
+            "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER",
+            "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER",
+            vk_format="VK_FORMAT_R32G32B32A32_SFLOAT",
+            tensor_type="tensor<1x8x8x4xf32>",
+            sampler_configs=[
+                LINEAR_BORDER_SAMPLER_CONFIG,
+                NEAREST_REPEAT_SAMPLER_CONFIG,
+            ],
+            shader_tensor_type="Image",
+        ),
+    ) as vgf:
+        input_resources = find_resource_indices(
+            vgf,
+            category=vgfpy.ResourceCategory.Input,
+            descriptor_type=VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+        )
+        assert len(input_resources) == 2
+
+        first_inputs = binding_slots_by_binding(
+            vgf, vgf.sequence.getSegmentInputBindingSlotsHandle(0)
+        )
+        second_inputs = binding_slots_by_binding(
+            vgf, vgf.sequence.getSegmentInputBindingSlotsHandle(1)
+        )
+        first_input_resource = first_inputs[0]
+        second_input_resource = second_inputs[0]
+        assert first_input_resource != second_input_resource
+
+        shared_alias_group = vgf.resources.getAliasGroupId(first_input_resource)
+        assert shared_alias_group is not None
+        assert (
+            vgf.resources.getAliasGroupId(second_input_resource) == shared_alias_group
+        )
+
+        assert_sampler_config(
+            vgf,
+            first_input_resource,
+            min_filter=VK_FILTER_LINEAR,
+            mag_filter=VK_FILTER_LINEAR,
+            address_mode_u=VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER,
+            address_mode_v=VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER,
+            border_color=VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK,
+        )
+        assert_sampler_config(
+            vgf,
+            second_input_resource,
+            min_filter=VK_FILTER_NEAREST,
+            mag_filter=VK_FILTER_NEAREST,
+            address_mode_u=VK_SAMPLER_ADDRESS_MODE_REPEAT,
+            address_mode_v=VK_SAMPLER_ADDRESS_MODE_REPEAT,
+            border_color=VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK,
+        )
+
+
+def test_sequence_input_can_be_returned_as_sequence_output(
+    model_converter_exe_path,
+):
+    with converted_mlir(
+        model_converter_exe_path,
+        input_passthrough_with_custom_mlir(),
+    ) as vgf:
+        model_outputs = vgf.sequence.getModelSequenceOutputBindingSlotsHandle()
+        assert vgf.sequence.getBindingsSize(model_outputs) == 2
+
+        passthrough_output_resource = vgf.sequence.getBindingSlotMrtIndex(
+            model_outputs, 0
+        )
+        custom_output_resource = vgf.sequence.getBindingSlotMrtIndex(model_outputs, 1)
+        assert (
+            vgf.resources.getCategory(passthrough_output_resource)
+            == vgfpy.ResourceCategory.Output
+        )
+        assert (
+            vgf.resources.getCategory(custom_output_resource)
+            == vgfpy.ResourceCategory.Output
+        )
 
 
 def test_custom_graph_custom_segments(model_converter_exe_path):


### PR DESCRIPTION
Plan VGF resources for each logical value before encoding segment bindings, instead of relying on serialization walk order to discover and reuse resources opportunistically.

Handle shared sequence inputs across multiple compute segments, including cases where the same logical value is viewed through different descriptor types such as image and buffer descriptors. When multiple resource views are required for one logical value, place those resources in the same alias group.

When graph segments consume compute-produced intermediates, create the required TENSOR_ARM resource view and alias it with the compute resource view. Preserve sampler metadata when creating aliased resource views.

Add coverage for shared-input fanout, descriptor-type aliasing, compute-to-graph transitions, and sampler preservation.

Change-Id: Iba310fcaf284fcdb60eadaa7eab7cade5299ea66