### PR TITLE
Preserve global TOSA graph constant IDs

### DIFF
--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -107,18 +107,15 @@ void Compiler::SetPassManager() {
         std::shared_ptr<VGFBuilder> builder = std::make_shared<class VGFBuilder>();
 
         _pm.nest<func::FuncOp>().addPass(createSignlessIntegerMarkingPass());
-        _pm.addPass(createModelPartitionMarkingPass());
-        _pm.addPass(createModelPartitioningPass({_options.analysis}));
-
         {
-            OpPassManager &sequenceNestedPM = _pm.nest<vgf::SequenceOp>();
-            OpPassManager &segmentNestedPM = sequenceNestedPM.nest<vgf::SegmentOp>();
-            OpPassManager &funcNestedPM = segmentNestedPM.nest<func::FuncOp>();
-
-            // NOTE: constant folding should be executed before the convert constants pass
+            OpPassManager &funcNestedPM = _pm.nest<func::FuncOp>();
+            // Run constant folding before assigning graph constant IDs so fold-created constants get stable,
+            // sequence-wide IDs before partitioning clones them into graph segments.
             funcNestedPM.addPass(mlir::tosa::createTosaLayerwiseConstantFoldPass());
             funcNestedPM.addPass(mlir::tosa::createConvertTosaConstantsPass());
         }
+        _pm.addPass(createModelPartitionMarkingPass());
+        _pm.addPass(createModelPartitioningPass({_options.analysis}));
 
         _pm.addPass(createCheckConstantSparsityPass());
         _pm.addPass(createVGFConstantsPass(builder));

--- a/src/conversion/model_partitioning.cpp
+++ b/src/conversion/model_partitioning.cpp
@@ -365,20 +365,68 @@ void insertPartitionResultInMap(const int64_t id, Value value, DenseMap<int64_t,
     map[id].insert(position, value);
 }
 
-SmallVector<Value> collectInputs(const SmallVector<Operation *> &ops) {
-    DenseSet<Operation *> knownOps(ops.begin(), ops.end());
-    DenseSet<Value> seenInputs;
+bool isCompileTimeTosaConstant(Operation *op) { return llvm::isa_and_nonnull<tosa::ConstOp, tosa::ConstShapeOp>(op); }
+
+bool isVulkanCustomShaderOperation(Operation *op) {
+    auto customOp = llvm::dyn_cast_or_null<tosa::CustomOp>(op);
+    return customOp && isVulkanCustomShaderOp(customOp);
+}
+
+bool hasNonRematerializableExternalUse(Operation *op, int64_t partitionId) {
+    for (Operation *user : op->getUsers()) {
+        if (llvm::isa<func::ReturnOp>(user) || isVulkanCustomShaderOperation(user)) {
+            return true;
+        }
+
+        auto userPartitionAttr = user->getAttrOfType<IntegerAttr>("graph_partition_id");
+        if (!userPartitionAttr || userPartitionAttr.getInt() == partitionId) {
+            continue;
+        }
+    }
+    return false;
+}
+
+struct PartitionDependencies {
     SmallVector<Value> inputs;
+    SmallVector<Value> compileTimeConstantsToClone;
+};
+
+PartitionDependencies collectPartitionDependencies(const SmallVector<Operation *> &ops,
+                                                   bool rematerializeCompileTimeConstants) {
+    DenseSet<Operation *> knownOps(ops.begin(), ops.end());
+    DenseSet<Value> seenRuntimeInputs;
+    DenseSet<Value> seenConstantsToClone;
+    PartitionDependencies dependencies;
     for (Operation *op : ops) {
         for (auto operand : op->getOperands()) {
             Operation *defOp = operand.getDefiningOp();
-            if (!knownOps.contains(defOp) && seenInputs.insert(operand).second) {
-                inputs.push_back(operand);
+            if (knownOps.contains(defOp)) {
+                continue;
+            }
+
+            if (rematerializeCompileTimeConstants && isCompileTimeTosaConstant(defOp)) {
+                if (seenConstantsToClone.insert(operand).second) {
+                    dependencies.compileTimeConstantsToClone.push_back(operand);
+                }
+                continue;
+            }
+
+            if (seenRuntimeInputs.insert(operand).second) {
+                dependencies.inputs.push_back(operand);
             }
         }
     }
 
-    return inputs;
+    return dependencies;
+}
+
+void cloneCompileTimeConstants(OpBuilder &builder, const SmallVector<Value> &constantsToClone, IRMapping &mapping) {
+    for (Value operand : constantsToClone) {
+        Operation *defOp = operand.getDefiningOp();
+        Operation *clonedConst = builder.clone(*defOp, mapping);
+        clonedConst->removeAttr("delete");
+        mapping.map(operand, clonedConst->getResult(0));
+    }
 }
 
 void deleteOldOps(ModuleOp moduleOp) {
@@ -419,6 +467,9 @@ class ModelPartitioningPass : public impl::ModelPartitioningPassBase<ModelPartit
             auto leafAttr = op->getAttrOfType<BoolAttr>("graph_partition_leaf_node");
             if (leafAttr.getValue()) {
                 for (Value value : op->getResults()) {
+                    if (isCompileTimeTosaConstant(op) && !hasNonRematerializableExternalUse(op, partitionId)) {
+                        continue;
+                    }
                     insertPartitionResultInMap(partitionId, value, partitionIdToResults);
                 }
             }
@@ -434,23 +485,22 @@ class ModelPartitioningPass : public impl::ModelPartitioningPassBase<ModelPartit
             for (int64_t partitionId = 0; partitionId <= highestPartitionId; ++partitionId) {
                 SmallVector<Operation *> partitionOps = partitionIdToOp[partitionId];
 
-                SmallVector<Value> inputs;
+                bool isComputeSegment = partitionOps.size() == 1 && isVulkanCustomShaderOperation(partitionOps[0]);
+                const auto segmentType = isComputeSegment ? vgf::SegmentTypeEnum::COMPUTE : vgf::SegmentTypeEnum::GRAPH;
+
+                PartitionDependencies dependencies;
                 // This ensures that unused arguments are passed through when there is one segment(partition)
                 if (highestPartitionId == 0) {
                     auto args = funcOp.getArguments();
-                    std::copy(args.begin(), args.end(), std::back_inserter(inputs));
+                    std::copy(args.begin(), args.end(), std::back_inserter(dependencies.inputs));
                 } else {
-                    inputs = collectInputs(partitionOps);
+                    dependencies = collectPartitionDependencies(partitionOps, !isComputeSegment);
                 }
                 SmallVector<Value> results = partitionIdToResults[partitionId];
 
                 const std::string segmentName = "graph_partition_" + std::to_string(partitionId);
                 const FunctionType segmentFunctionType =
-                    builder.getFunctionType(ValueRange(inputs).getTypes(), ValueRange(results).getTypes());
-
-                bool isComputeSegment = partitionOps.size() == 1 && llvm::isa<tosa::CustomOp>(partitionOps[0]) &&
-                                        isVulkanCustomShaderOp(llvm::cast<tosa::CustomOp>(partitionOps[0]));
-                const auto segmentType = isComputeSegment ? vgf::SegmentTypeEnum::COMPUTE : vgf::SegmentTypeEnum::GRAPH;
+                    builder.getFunctionType(ValueRange(dependencies.inputs).getTypes(), ValueRange(results).getTypes());
 
                 auto segmentOp = vgf::SegmentOp::create(builder, funcOp.getLoc(), segmentName, segmentType,
                                                         segmentFunctionType, nullptr, nullptr);
@@ -462,7 +512,7 @@ class ModelPartitioningPass : public impl::ModelPartitioningPassBase<ModelPartit
 
                     if (isComputeSegment) {
                         IRMapping segmentMapping;
-                        for (auto [input, segmentOpArg] : llvm::zip(inputs, segmentOp.getArguments())) {
+                        for (auto [input, segmentOpArg] : llvm::zip(dependencies.inputs, segmentOp.getArguments())) {
                             segmentMapping.map(input, segmentOpArg);
                         }
 
@@ -486,10 +536,11 @@ class ModelPartitioningPass : public impl::ModelPartitioningPassBase<ModelPartit
                             Block *funcBlock = newFuncOp.addEntryBlock();
                             builder.setInsertionPoint(funcBlock, funcBlock->end());
                             IRMapping funcMapping;
-                            for (auto [input, newFunOpArg] : llvm::zip(inputs, newFuncOp.getArguments())) {
+                            for (auto [input, newFunOpArg] : llvm::zip(dependencies.inputs, newFuncOp.getArguments())) {
                                 funcMapping.map(input, newFunOpArg);
                             }
 
+                            cloneCompileTimeConstants(builder, dependencies.compileTimeConstantsToClone, funcMapping);
                             for (Operation *op : partitionOps) {
                                 builder.clone(*op, funcMapping);
                                 op->setAttr("delete", BoolAttr::get(context, true));
@@ -504,7 +555,7 @@ class ModelPartitioningPass : public impl::ModelPartitioningPassBase<ModelPartit
                 }
 
                 llvm::SmallVector<Value, 4> runInputs;
-                std::transform(inputs.begin(), inputs.end(), std::back_inserter(runInputs),
+                std::transform(dependencies.inputs.begin(), dependencies.inputs.end(), std::back_inserter(runInputs),
                                [&](Value value) { return externalMapping.lookupOrDefault(value); });
                 auto segmentRunOp = vgf::SegmentRunOp::create(builder, segmentOp.getLoc(), segmentOp.getResultTypes(),
                                                               SymbolRefAttr::get(segmentOp), ValueRange(runInputs));

--- a/src/conversion/serialize_vgf.cpp
+++ b/src/conversion/serialize_vgf.cpp
@@ -5,6 +5,7 @@
 
 #include "conversion/resource_planner.hpp"
 #include "include/passes.hpp"
+#include "mlir/Dialect/SPIRV/IR/SPIRVOps.h"
 #include "mlir/Target/SPIRV/Serialization.h"
 #include "utils.hpp"
 #include "vgf/encoder.hpp"
@@ -58,6 +59,16 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
     }
 
   private:
+    std::vector<ConstantRef> getSegmentConstantRefs(spirv::ModuleOp spirvModuleOp) const {
+        std::vector<uint32_t> ids;
+        spirvModuleOp.walk([&](spirv::GraphConstantARMOp graphConstantOp) {
+            ids.push_back(static_cast<uint32_t>(graphConstantOp.getGraphConstantId()));
+        });
+        std::sort(ids.begin(), ids.end());
+        ids.erase(std::unique(ids.begin(), ids.end()), ids.end());
+        return _VGFBuilder->getConstantRefs(ids);
+    }
+
     mlir::LogicalResult serializeModule(mlir::vgf::SequenceOp &sequenceOp) {
 
         // Fetch input/output names if available
@@ -163,7 +174,7 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
 
                     _VGFBuilder->getEncoder()->AddSegmentInfo(
                         computeModuleRef, "compute_segment_" + std::to_string(computeSegmentId++), descriptorSetInfos,
-                        segmentInputBindings, segmentOutputBindings, _VGFBuilder->getConstantRefs(), dispatchShape);
+                        segmentInputBindings, segmentOutputBindings, {}, dispatchShape);
 
                     return WalkResult::advance();
                 });
@@ -194,10 +205,11 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
 
                         const DescriptorSetInfoRef descSetInfo =
                             _VGFBuilder->getEncoder()->AddDescriptorSetInfo(segmentAllBindings);
+                        const auto segmentConstants = getSegmentConstantRefs(spirvModuleOp);
 
                         _VGFBuilder->getEncoder()->AddSegmentInfo(
                             graphModuleRef, "graph_segment_" + std::to_string(graphSegmentId++), {descSetInfo},
-                            segmentInputBindings, segmentOutputBindings, _VGFBuilder->getConstantRefs());
+                            segmentInputBindings, segmentOutputBindings, segmentConstants);
 
                         return WalkResult::advance();
                     });

--- a/src/conversion/vgf_constants.cpp
+++ b/src/conversion/vgf_constants.cpp
@@ -10,7 +10,7 @@
 #include "vgf_builder.hpp"
 
 #include <fstream>
-#include <set>
+#include <map>
 
 using namespace mlsdk::vgflib;
 
@@ -47,47 +47,48 @@ class VGFConstantsPass : public impl::VGFConstantsPassBase<VGFConstantsPass> {
             }
             return false;
         };
-        return constOp.getType().getElementType().isSignlessInteger() &&
+        return constOp.getType().getElementType().isSignlessInteger() && !constOp->use_empty() &&
                llvm::all_of(constOp->getUsers(), onlyRescaleOpsWithUnsignedInput);
     }
 
     mlir::LogicalResult serializeConstants(mlir::ModuleOp moduleOp) {
 
-        std::set<uint32_t> processedGraphConstants;
-        WalkResult walkResult = moduleOp.walk([this, &processedGraphConstants](Operation *op) {
+        std::map<uint32_t, tosa::ConstOp> constantsById;
+        moduleOp.walk([&constantsById](Operation *op) {
             if (auto constOp = llvm::dyn_cast<tosa::ConstOp>(op)) {
                 const auto id = tosa::getGraphIdForConst(constOp);
                 if (id.has_value()) {
-                    if (processedGraphConstants.insert(id.value()).second) {
-                        const ShapedType type = convertShapedType(constOp.getResult().getType());
-                        VGFBuilder::VkFormat vkFormat;
-                        if (_VGFBuilder
-                                ->mlirTypeToVkFormat(type.getElementType(), vkFormat, checkIfUnsignedRequired(constOp))
-                                .failed()) {
-                            llvm::errs() << "Unsupported type for tosa.const op at " << op->getLoc() << "\n";
-                            return WalkResult::interrupt();
-                        }
-
-                        auto format = static_cast<FormatType>(vkFormat);
-                        ResourceRef resourceRef =
-                            _VGFBuilder->getEncoder()->AddConstantResource(format, type.getShape(), {});
-
-                        int64_t sparsityDimension = -1;
-                        auto attr = op->getAttrOfType<IntegerAttr>("constant_2_4_sparse_on_dimension");
-                        if (attr != nullptr) {
-                            sparsityDimension = attr.getInt();
-                        }
-
-                        auto attrVal = llvm::dyn_cast<DenseTypedElementsAttr>(constOp.getValuesAttr());
-                        serializeConstantData(attrVal, resourceRef, sparsityDimension);
-                    }
+                    constantsById.try_emplace(id.value(), constOp);
                 }
             }
-            return WalkResult::advance();
         });
 
-        if (walkResult.wasInterrupted()) {
-            return mlir::failure();
+        uint32_t expectedId = 0;
+        for (auto &[id, constOp] : constantsById) {
+            if (id != expectedId) {
+                return constOp.emitError("missing TOSA graph constant id ")
+                       << expectedId << "; VGF constants must be serialized in global graph constant id order";
+            }
+
+            const ShapedType type = convertShapedType(constOp.getResult().getType());
+            VGFBuilder::VkFormat vkFormat;
+            if (_VGFBuilder->mlirTypeToVkFormat(type.getElementType(), vkFormat, checkIfUnsignedRequired(constOp))
+                    .failed()) {
+                return constOp.emitError("unsupported type for tosa.const op: ") << type.getElementType();
+            }
+
+            auto format = static_cast<FormatType>(vkFormat);
+            ResourceRef resourceRef = _VGFBuilder->getEncoder()->AddConstantResource(format, type.getShape(), {});
+
+            int64_t sparsityDimension = -1;
+            auto attr = constOp->getAttrOfType<IntegerAttr>("constant_2_4_sparse_on_dimension");
+            if (attr != nullptr) {
+                sparsityDimension = attr.getInt();
+            }
+
+            auto attrVal = llvm::dyn_cast<DenseTypedElementsAttr>(constOp.getValuesAttr());
+            serializeConstantData(attrVal, resourceRef, sparsityDimension);
+            ++expectedId;
         }
 
         return mlir::success();

--- a/src/include/passes.td
+++ b/src/include/passes.td
@@ -56,6 +56,11 @@ def ModelPartitioningPass : Pass<"model-partitioning", "mlir::ModuleOp"> {
   let description = [{
     Split the model in several modules one per partition following the marking done by the ModelPartitionMarkingPass.
   }];
+  let dependentDialects = [
+    "func::FuncDialect",
+    "tosa::TosaDialect",
+    "vgf::VGFDialect"
+  ];
   let options = [
       Option<"analysis", "analysis", "bool", "false","Analysis">
   ];

--- a/src/opt.cpp
+++ b/src/opt.cpp
@@ -8,6 +8,7 @@
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
 #include "mlir/Dialect/Tosa/Transforms/Passes.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
+#include "vgf-dialect/VGFDialect.h"
 
 using namespace mlir;
 using namespace mlir::model_converter_passes;

--- a/src/vgf_builder.hpp
+++ b/src/vgf_builder.hpp
@@ -7,6 +7,11 @@
 
 #include <vgf/encoder.hpp>
 
+#include <algorithm>
+#include <cstdint>
+#include <iterator>
+#include <vector>
+
 namespace mlsdk::model_converter {
 
 class VGFBuilder {
@@ -15,6 +20,14 @@ class VGFBuilder {
     VGFBuilder() : _encoder(mlsdk::vgflib::CreateEncoder(0)) {}
     std::shared_ptr<mlsdk::vgflib::Encoder> getEncoder() const { return _encoder; }
     const std::vector<mlsdk::vgflib::ConstantRef> &getConstantRefs() const { return _constantRefs; }
+
+    std::vector<mlsdk::vgflib::ConstantRef> getConstantRefs(const std::vector<uint32_t> &ids) const {
+        std::vector<mlsdk::vgflib::ConstantRef> refs;
+        refs.reserve(ids.size());
+        std::transform(ids.begin(), ids.end(), std::back_inserter(refs),
+                       [this](uint32_t id) { return _constantRefs[id]; });
+        return refs;
+    }
 
     void AddConstantRef(mlsdk::vgflib::ConstantRef constRef) { _constantRefs.emplace_back(constRef); }
 

--- a/test/lit/model-partitioning-rematerialize-constants.mlir
+++ b/test/lit/model-partitioning-rematerialize-constants.mlir
@@ -1,0 +1,37 @@
+//
+// SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+
+// RUN: model-converter-opt --model-partition-marking --model-partitioning %s | FileCheck %s
+
+// CHECK-LABEL: vgf.sequence @main
+// CHECK: vgf.segment @graph_partition_0
+// CHECK: func.func @graph_partition_0(%{{.*}}: tensor<4xi8>) -> tensor<4xi8>
+// CHECK: vgf.segment @graph_partition_1
+// CHECK: vgf.segment @graph_partition_2
+func.func @main(%arg0: tensor<4xi8> {tf_saved_model.index_path = ["input_0"]}) -> (tensor<2x2xi8> {tf_saved_model.index_path = ["output_0"]}) attributes {tf.entry_function = {inputs = "input_0", outputs = "output_0"}} {
+  // The table is consumed after the partition boundary and should be cloned into
+  // the consuming graph segment instead of becoming a runtime input.
+  // CHECK: func.func @graph_partition_2(%{{.*}}: tensor<4xi8>) -> tensor<2x2xi8>
+  // CHECK-NOT: tensor<256xi8>
+  // CHECK: "tosa.const"() <{values = dense<0> : tensor<256xi8>}> {graph_partition_id = 0 : i32, graph_partition_leaf_node = true, spirv_graph_constant_id = 0 : i32} : () -> tensor<256xi8>
+  %table = "tosa.const"() {spirv_graph_constant_id = 0 : i32, values = dense<0> : tensor<256xi8>} : () -> tensor<256xi8>
+
+  // Shape constants are also compile-time constants and should be cloned rather
+  // than added as graph segment arguments.
+  // CHECK-NOT: !tosa.shape<2>
+  // CHECK: tosa.const_shape
+  // CHECK-SAME: graph_partition_id = 0 : i32
+  // CHECK-SAME: graph_partition_leaf_node = true
+  // CHECK-SAME: values = dense<2> : tensor<2xindex>
+  // CHECK: tosa.table
+  // CHECK: tosa.reshape
+  %shape = "tosa.const_shape"() {values = dense<[2, 2]> : tensor<2xindex>} : () -> !tosa.shape<2>
+
+  %0 = tosa.abs %arg0 : (tensor<4xi8>) -> tensor<4xi8>
+  %1 = tosa.custom %0 {domain_name = "com.arm.VulkanCustomShader", implementation_attrs = "{\22entry_point\22:\22main\22,\22is_vkshader\22:true,\22workgroup_sizes\22:[1,1,1],\22input_0_binding\22:0,\22input_0_descriptorset\22:0,\22input_0_type\22:\22TENSOR\22,\22input_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22input_0_vkformat\22:\22VK_FORMAT_R8_SINT\22,\22output_0_binding\22:1,\22output_0_descriptorset\22:0,\22output_0_type\22:\22TENSOR\22,\22output_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22output_0_vkformat\22:\22VK_FORMAT_R8_SINT\22}", operator_name = "partition_barrier"} : (tensor<4xi8>) -> tensor<4xi8>
+  %2 = tosa.table %1, %table : (tensor<4xi8>, tensor<256xi8>) -> tensor<4xi8>
+  %3 = tosa.reshape %2, %shape : (tensor<4xi8>, !tosa.shape<2>) -> tensor<2x2xi8>
+  return %3 : tensor<2x2xi8>
+}

--- a/test/test_model_converter_graph_constants_v100.py
+++ b/test/test_model_converter_graph_constants_v100.py
@@ -1,0 +1,136 @@
+#
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+import json
+
+import vgfpy
+from model_converter_helpers import converted_mlir
+from test_model_converter_core_v100 import main_mlir
+from vgf_decoder import VK_FORMAT_R8_SINT
+
+OP_GRAPH_CONSTANT_ARM = 4181
+
+
+def vulkan_custom_shader_attrs():
+    return json.dumps(
+        json.dumps(
+            {
+                "entry_point": "main",
+                "is_vkshader": True,
+                "workgroup_sizes": [1, 1, 1],
+                "input_0_binding": 0,
+                "input_0_descriptorset": 0,
+                "input_0_type": "TENSOR",
+                "input_0_vkdescriptortype": "VK_DESCRIPTOR_TYPE_TENSOR_ARM",
+                "input_0_vkformat": "VK_FORMAT_R8_SINT",
+                "output_0_binding": 1,
+                "output_0_descriptorset": 0,
+                "output_0_type": "TENSOR",
+                "output_0_vkdescriptortype": "VK_DESCRIPTOR_TYPE_TENSOR_ARM",
+                "output_0_vkformat": "VK_FORMAT_R8_SINT",
+            },
+            separators=(",", ":"),
+        )
+    )
+
+
+def graph_constant_ids(spirv_words):
+    ids = []
+    words = list(spirv_words)
+    offset = 5
+    while offset < len(words):
+        word = words[offset]
+        word_count = word >> 16
+        opcode = word & 0xFFFF
+        if opcode == OP_GRAPH_CONSTANT_ARM:
+            ids.append(words[offset + 3])
+        offset += word_count
+    return ids
+
+
+def partitioned_table_mlir(shared_constant=False):
+    shared_table = ""
+    shared_return = "%4"
+    if shared_constant:
+        shared_table = (
+            "    %5 = tosa.table %4, %c0 : "
+            "(tensor<4xi8>, tensor<256xi8>) -> tensor<4xi8>\n"
+        )
+        shared_return = "%5"
+
+    body = f"""    %c0 = "tosa.const"() {{values = dense<0> : tensor<256xi8>}} : () -> tensor<256xi8>
+    %c1 = "tosa.const"() {{values = dense<1> : tensor<256xi8>}} : () -> tensor<256xi8>
+    %c2 = "tosa.const"() {{values = dense<2> : tensor<256xi8>}} : () -> tensor<256xi8>
+    %0 = tosa.table %arg0, %c0 : (tensor<4xi8>, tensor<256xi8>) -> tensor<4xi8>
+    %1 = tosa.table %0, %c2 : (tensor<4xi8>, tensor<256xi8>) -> tensor<4xi8>
+    %2 = tosa.custom %1 {{domain_name = "com.arm.VulkanCustomShader", implementation_attrs = {vulkan_custom_shader_attrs()}, operator_name = "partition_barrier"}} : (tensor<4xi8>) -> tensor<4xi8>
+    %4 = tosa.table %2, %c1 : (tensor<4xi8>, tensor<256xi8>) -> tensor<4xi8>
+{shared_table}"""
+
+    return main_mlir(
+        arguments='%arg0: tensor<4xi8> {tf_saved_model.index_path = ["input_0"]}',
+        result='(tensor<4xi8> {tf_saved_model.index_path = ["output_0"]})',
+        entry_inputs="input_0",
+        entry_outputs="output_0",
+        body=body,
+        return_value=f"{shared_return} : tensor<4xi8>",
+    )
+
+
+def graph_segment_constant_indexes(vgf):
+    segment_indexes = []
+    module_ids = []
+    for segment_index in range(vgf.sequence.modelSequenceTableSize()):
+        if vgf.sequence.getSegmentType(segment_index) != vgfpy.ModuleType.Graph:
+            continue
+        module_index = vgf.sequence.getSegmentModuleIndex(segment_index)
+        segment_indexes.append(
+            list(vgf.sequence.getSegmentConstantIndexes(segment_index))
+        )
+        module_ids.append(
+            sorted(graph_constant_ids(vgf.modules.getSPIRVModuleCode(module_index)))
+        )
+    return segment_indexes, module_ids
+
+
+def segment_constant_indexes(vgf):
+    indexes = []
+    for segment_index in range(vgf.sequence.modelSequenceTableSize()):
+        segment_constants = vgf.sequence.getSegmentConstantIndexes(segment_index)
+        indexes.append([] if segment_constants is None else list(segment_constants))
+    return indexes
+
+
+def assert_constant_table(vgf, expected_values):
+    assert vgf.constants.size() == len(expected_values)
+    for index, expected_value in enumerate(expected_values):
+        assert vgf.constants.getConstantMrtIndex(index) == index
+        assert vgf.resources.getCategory(index) == vgfpy.ResourceCategory.Constant
+        assert int(vgf.resources.getVkFormat(index)) == VK_FORMAT_R8_SINT
+        assert list(vgf.resources.getTensorShape(index)) == [256]
+        assert (
+            vgf.constants.getConstant(index).tobytes() == bytes([expected_value]) * 256
+        )
+
+
+def test_partitioned_graph_constants_use_global_sparse_ids(model_converter_exe_path):
+    with converted_mlir(model_converter_exe_path, partitioned_table_mlir()) as vgf:
+        segment_constants, module_ids = graph_segment_constant_indexes(vgf)
+
+        assert_constant_table(vgf, [0, 1, 2])
+        assert segment_constant_indexes(vgf) == [[0, 2], [], [1]]
+        assert segment_constants == [[0, 2], [1]]
+        assert module_ids == [[0, 2], [1]]
+
+
+def test_rematerialized_shared_graph_constant_serializes_once(model_converter_exe_path):
+    with converted_mlir(
+        model_converter_exe_path, partitioned_table_mlir(shared_constant=True)
+    ) as vgf:
+        segment_constants, module_ids = graph_segment_constant_indexes(vgf)
+
+        assert_constant_table(vgf, [0, 1, 2])
+        assert segment_constant_indexes(vgf) == [[0, 2], [], [0, 1]]
+        assert segment_constants == [[0, 2], [0, 1]]
+        assert module_ids == [[0, 2], [0, 1]]


### PR DESCRIPTION
Assign TOSA graph constant IDs before partitioning so cloned constants keep sequence-wide identity, and rematerialize compile-time constants inside graph segments instead of promoting them to segment runtime inputs.

Serialize VGF constants in spirv_graph_constant_id order and populate graph SegmentInfo.constants with only the global constant IDs used by each SPIR-V module. Keep duplicate same-ID constants consistent with the previous first-seen serialization behavior while preserving global table ordering.

Add coverage for cross-partition compile-time constants, sparse per-segment constant lists, and shared rematerialized constants.

Change-Id: I0a24d233854a92a829c8a47dc3c21bb95bdbb1c4