### PR TITLE
Preserve passthrough graphs after early TOSA folding

### DIFF
--- a/src/conversion/model_partitioning.cpp
+++ b/src/conversion/model_partitioning.cpp
@@ -482,21 +482,34 @@ class ModelPartitioningPass : public impl::ModelPartitioningPassBase<ModelPartit
             builder.setInsertionPoint(oldTerminator);
 
             IRMapping externalMapping;
-            for (int64_t partitionId = 0; partitionId <= highestPartitionId; ++partitionId) {
+            const bool createPassthroughSegment = highestPartitionId < 0;
+            const int64_t lastPartitionId = createPassthroughSegment ? 0 : highestPartitionId;
+            if (createPassthroughSegment) {
+                DenseSet<Value> seenResults;
+                for (Value operand : oldTerminator->getOperands()) {
+                    if (seenResults.insert(operand).second) {
+                        partitionIdToResults[0].push_back(operand);
+                    }
+                }
+            }
+
+            for (int64_t partitionId = 0; partitionId <= lastPartitionId; ++partitionId) {
                 SmallVector<Operation *> partitionOps = partitionIdToOp[partitionId];
 
                 bool isComputeSegment = partitionOps.size() == 1 && isVulkanCustomShaderOperation(partitionOps[0]);
                 const auto segmentType = isComputeSegment ? vgf::SegmentTypeEnum::COMPUTE : vgf::SegmentTypeEnum::GRAPH;
 
                 PartitionDependencies dependencies;
-                // This ensures that unused arguments are passed through when there is one segment(partition)
-                if (highestPartitionId == 0) {
+                SmallVector<Value> results = partitionIdToResults[partitionId];
+                if (createPassthroughSegment) {
+                    dependencies.inputs = results;
+                } else if (highestPartitionId == 0) {
+                    // This ensures that unused arguments are passed through when there is one segment(partition)
                     auto args = funcOp.getArguments();
                     std::copy(args.begin(), args.end(), std::back_inserter(dependencies.inputs));
                 } else {
                     dependencies = collectPartitionDependencies(partitionOps, !isComputeSegment);
                 }
-                SmallVector<Value> results = partitionIdToResults[partitionId];
 
                 const std::string segmentName = "graph_partition_" + std::to_string(partitionId);
                 const FunctionType segmentFunctionType =

--- a/test/test_model_converter_core_v100.py
+++ b/test/test_model_converter_core_v100.py
@@ -87,6 +87,18 @@ def add_mlir():
     )
 
 
+def direct_passthrough_mlir():
+    return main_mlir(
+        arguments='%arg0: tensor<49x38x55xi16> {tf_saved_model.index_path = ["input_0"]}',
+        result='(tensor<49x38x55xi16> {tf_saved_model.index_path = ["output_0"]})',
+        entry_inputs="tosa_deserialized_input_0:0",
+        entry_outputs="tosa_deserialized_output_0:0",
+        exported_name="tosa_deserialized",
+        body="",
+        return_value="%arg0 : tensor<49x38x55xi16>",
+    )
+
+
 def conv2d_mlir():
     body = """
     %0 = "tosa.const"() {values = dense<0> : tensor<16xi32>} : () -> tensor<16xi32>
@@ -211,6 +223,29 @@ def inlined_higher_rank_constant_mlir():
                 "constants": [],
             },
             id="add",
+        ),
+        pytest.param(
+            direct_passthrough_mlir(),
+            {
+                "resources": [
+                    (
+                        vgfpy.ResourceCategory.Input,
+                        VK_FORMAT_R16_SINT,
+                        [49, 38, 55],
+                    ),
+                    (
+                        vgfpy.ResourceCategory.Output,
+                        VK_FORMAT_R16_SINT,
+                        [49, 38, 55],
+                    ),
+                ],
+                "segment_inputs": [(0, 0)],
+                "segment_outputs": [(1, 1)],
+                "model_inputs": [(0, 0, "tosa_deserialized_input_0:0")],
+                "model_outputs": [(1, 1, "tosa_deserialized_output_0:0")],
+                "constants": [],
+            },
+            id="direct-passthrough",
         ),
         pytest.param(
             conv2d_mlir(),


### PR DESCRIPTION
Change-Id: Ie694311c326a806bf7e157d7a6f81773d59fc566