### PR TITLE
Reuse compute-safe graph partition assignment

### DIFF
--- a/src/conversion/model_partition_marking.cpp
+++ b/src/conversion/model_partition_marking.cpp
@@ -15,11 +15,14 @@ namespace {
 
 enum class PartitionKind { Graph, Compute };
 
-int64_t assignStandaloneGraphPartition(const int64_t highestPartitionId, const PartitionKind highestPartitionKind) {
+int64_t assignGraphPartitionAfterCompute(const int64_t candidatePartitionId, const int64_t highestPartitionId,
+                                         const PartitionKind highestPartitionKind) {
     if (highestPartitionId < 0) {
-        return 0;
+        return std::max(candidatePartitionId, int64_t(0));
     }
-    return highestPartitionKind == PartitionKind::Compute ? highestPartitionId + 1 : highestPartitionId;
+    const int64_t nextComputeSafePartition =
+        highestPartitionKind == PartitionKind::Compute ? highestPartitionId + 1 : highestPartitionId;
+    return std::max(candidatePartitionId, nextComputeSafePartition);
 }
 
 class ModelPartitionMarkingPass : public impl::ModelPartitionMarkingPassBase<ModelPartitionMarkingPass> {
@@ -69,7 +72,8 @@ class ModelPartitionMarkingPass : public impl::ModelPartitionMarkingPassBase<Mod
                         int64_t parentPartitionId = input->getAttrOfType<IntegerAttr>("graph_partition_id").getInt();
                         if (auto parentCustomOp = llvm::dyn_cast<mlir::tosa::CustomOp>(input);
                             parentCustomOp && isVulkanCustomShaderOp(parentCustomOp)) {
-                            parentPartitionId = std::max(highestPartitionId, parentPartitionId + 1);
+                            parentPartitionId = assignGraphPartitionAfterCompute(
+                                parentPartitionId + 1, highestPartitionId, highestPartitionKind);
                         }
                         partitionId = std::max(partitionId, parentPartitionId);
                     }
@@ -78,7 +82,8 @@ class ModelPartitionMarkingPass : public impl::ModelPartitionMarkingPassBase<Mod
                     // Graph ops without any defining producer in the current sequence stay in a graph-owned
                     // partition. If the most recent partition is compute, start a new graph partition so the
                     // Vulkan custom segment remains single-op.
-                    partitionId = assignStandaloneGraphPartition(highestPartitionId, highestPartitionKind);
+                    partitionId =
+                        assignGraphPartitionAfterCompute(partitionId, highestPartitionId, highestPartitionKind);
                 }
 
                 // Set leaf node flags after the current op's final partition is known. This keeps cross-partition

--- a/test/lit/model-partition-marking-vulkan-custom-trailing-graph-ops.mlir
+++ b/test/lit/model-partition-marking-vulkan-custom-trailing-graph-ops.mlir
@@ -110,3 +110,22 @@ func.func @cross_partition_input_before_raising_operand(%arg0: tensor<1x16x16x16
   %3 = tosa.add %0, %2 : (tensor<1x16x16x16xf32>, tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
   return %3 : tensor<1x16x16x16xf32>
 }
+
+// -----
+
+// CHECK-LABEL: func.func @graph_op_after_independent_compute_consumes_earlier_compute
+func.func @graph_op_after_independent_compute_consumes_earlier_compute(%arg0: tensor<1x16x16x16xf32> {tf_saved_model.index_path = ["input_0"]}, %arg1: tensor<1x16x16x16xf32> {tf_saved_model.index_path = ["input_1"]}, %arg2: tensor<1x16x16x16xf32> {tf_saved_model.index_path = ["input_2"]}) -> (tensor<1x16x16x16xf32> {tf_saved_model.index_path = ["output_0"]}) attributes {tf.entry_function = {inputs = "input_0,input_1,input_2", outputs = "output_0"}, tf_saved_model.exported_names = ["serving_default"]} {
+  // CHECK: tosa.custom
+  // CHECK-SAME: graph_partition_id = 0 : i32
+  // CHECK-SAME: graph_partition_leaf_node = true
+  %0 = tosa.custom %arg0, %arg1 {domain_name = "com.arm.VulkanCustomShader", implementation_attrs = "{\22entry_point\22:\22main\22,\22is_vkshader\22:true,\22workgroup_sizes\22:[16,16,16],\22input_0_binding\22:0,\22input_0_descriptorset\22:0,\22input_0_type\22:\22TENSOR\22,\22input_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22input_0_vkformat\22:\22VK_FORMAT_R32_SFLOAT\22,\22input_1_binding\22:1,\22input_1_descriptorset\22:0,\22input_1_type\22:\22TENSOR\22,\22input_1_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22input_1_vkformat\22:\22VK_FORMAT_R32_SFLOAT\22,\22output_0_binding\22:2,\22output_0_descriptorset\22:0,\22output_0_type\22:\22TENSOR\22,\22output_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22output_0_vkformat\22:\22VK_FORMAT_R32_SFLOAT\22}", operator_name = "test_first_shader"} : (tensor<1x16x16x16xf32>, tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
+  // CHECK: tosa.custom
+  // CHECK-SAME: graph_partition_id = 1 : i32
+  // CHECK-SAME: graph_partition_leaf_node = true
+  %1 = tosa.custom %arg1, %arg2 {domain_name = "com.arm.VulkanCustomShader", implementation_attrs = "{\22entry_point\22:\22main\22,\22is_vkshader\22:true,\22workgroup_sizes\22:[16,16,16],\22input_0_binding\22:0,\22input_0_descriptorset\22:0,\22input_0_type\22:\22TENSOR\22,\22input_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22input_0_vkformat\22:\22VK_FORMAT_R32_SFLOAT\22,\22input_1_binding\22:1,\22input_1_descriptorset\22:0,\22input_1_type\22:\22TENSOR\22,\22input_1_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22input_1_vkformat\22:\22VK_FORMAT_R32_SFLOAT\22,\22output_0_binding\22:2,\22output_0_descriptorset\22:0,\22output_0_type\22:\22TENSOR\22,\22output_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22output_0_vkformat\22:\22VK_FORMAT_R32_SFLOAT\22}", operator_name = "test_second_shader"} : (tensor<1x16x16x16xf32>, tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
+  // CHECK: tosa.abs
+  // CHECK-SAME: graph_partition_id = 2 : i32
+  // CHECK-SAME: graph_partition_leaf_node = true
+  %2 = tosa.abs %0 : (tensor<1x16x16x16xf32>) -> tensor<1x16x16x16xf32>
+  return %2 : tensor<1x16x16x16xf32>
+}


### PR DESCRIPTION
Generalize the graph partition assignment rule introduced for standalone zero-input graph ops so it also applies when graph ops consume Vulkan custom shader results.

This prevents graph ops from reusing the latest compute partition ID when they consume an earlier custom shader result, avoiding mixed graph/custom partitions and invalid shader_placeholder placement.

Add a lit regression with two independent Vulkan custom ops followed by a graph op consuming the earlier custom result.

Change-Id: Ice7706686c10020f1c5319a0069940262a339bdd