### PR TITLE
Update llvm dep

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,6 +235,7 @@ if(MODEL_CONVERTER_BUILD_TESTS)
 
     target_link_libraries(model-converter-opt PRIVATE
         MLIROptLib
+        MLIRTosaTransforms
         model-converter-passes-lib)
 
     add_dependencies(model-converter-opt model-converter-passes-lib)

--- a/cmake/llvm-project.cmake
+++ b/cmake/llvm-project.cmake
@@ -33,7 +33,7 @@ endfunction()
 
 if(EXISTS ${LLVM_PATH}/llvm/CMakeLists.txt)
     if(MODEL_CONVERTER_APPLY_LLVM_PATCH)
-        set(LLVM_PATCH_COMMIT_MESSAGE "llvm-changes-for-model-converter-05-05-2026")
+        set(LLVM_PATCH_COMMIT_MESSAGE "llvm-changes-for-model-converter-04-06-2026")
         execute_process(
             COMMAND git log --grep=${LLVM_PATCH_COMMIT_MESSAGE}
             WORKING_DIRECTORY "${LLVM_PATH}"

--- a/cmake/toolchain/gnu_compiler_options.cmake
+++ b/cmake/toolchain/gnu_compiler_options.cmake
@@ -1,7 +1,11 @@
 #
-# SPDX-FileCopyrightText: Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2024-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
 # Compilation warnings
 set(ML_SDK_MODEL_CONVERTER_COMPILE_OPTIONS -Werror -Wall -Wextra -Wsign-conversion -Wconversion -Wpedantic)
+
+# GCC can report a false-positive maybe-uninitialized warning from generated
+# MLIR operation property hashing when compiling with optimizations.
+list(APPEND ML_SDK_MODEL_CONVERTER_COMPILE_OPTIONS -Wno-maybe-uninitialized)

--- a/patches/llvm.patch
+++ b/patches/llvm.patch
@@ -1,2200 +1,517 @@
 From: svc_sdk <svc_sdk@arm.com>
 Date: Thu Feb 19 00:00:00 2026
-Subject: llvm-changes-for-model-converter-05-05-2026
+Subject: llvm-changes-for-model-converter-04-06-2026
 
-diff --git a/mlir/include/mlir/Conversion/Passes.h b/mlir/include/mlir/Conversion/Passes.h
-index a54b98004c3b..07b5fc6e4f80 100644
---- a/mlir/include/mlir/Conversion/Passes.h
-+++ b/mlir/include/mlir/Conversion/Passes.h
-@@ -76,6 +76,8 @@
- #include "mlir/Conversion/TosaToLinalg/TosaToLinalg.h"
- #include "mlir/Conversion/TosaToMLProgram/TosaToMLProgram.h"
- #include "mlir/Conversion/TosaToSCF/TosaToSCF.h"
-+#include "mlir/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosa.h"
-+#include "mlir/Conversion/TosaToSPIRVTosa/ConvertTosaConstants.h"
- #include "mlir/Conversion/TosaToTensor/TosaToTensor.h"
- #include "mlir/Conversion/UBToLLVM/UBToLLVM.h"
- #include "mlir/Conversion/UBToSPIRV/UBToSPIRV.h"
 diff --git a/mlir/include/mlir/Conversion/Passes.td b/mlir/include/mlir/Conversion/Passes.td
-index d401b56c7602..f36a055f518c 100644
+index c30dd3b07d02..c5eebb1fee97 100644
 --- a/mlir/include/mlir/Conversion/Passes.td
 +++ b/mlir/include/mlir/Conversion/Passes.td
-@@ -1410,6 +1410,40 @@ def TosaToSCFPass : Pass<"tosa-to-scf"> {
+@@ -1437,6 +1437,13 @@ def TosaToSPIRVTosa : Pass<"tosa-to-spirv-tosa"> {
+     lowering supported TOSA ops to `spirv.Tosa.*`, and rewriting TOSA tensor
+     and shape types to the corresponding SPIR-V ARM tensor types.
    }];
++  let options = [
++    ListOption<"customOpDomainToOpcode", "custom-op-domain-to-opcode",
++               "std::pair<std::string, int32_t>",
++               "Map TOSA custom op domains to spirv.ExperimentalML.Call "
++               "opcodes. Entries use <domain>:<opcode> and can be specified "
++               "multiple times.">
++  ];
+ 
+   let constructor = "tosa::createTosaToSPIRVTosa()";
+ }
+diff --git a/mlir/include/mlir/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosa.h b/mlir/include/mlir/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosa.h
+index d03f09f9be78..9a42cf75f187 100644
+--- a/mlir/include/mlir/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosa.h
++++ b/mlir/include/mlir/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosa.h
+@@ -16,8 +16,11 @@
+ 
+ #include "mlir/Dialect/SPIRV/Transforms/SPIRVConversion.h"
+ #include "mlir/Pass/Pass.h"
++#include "llvm/ADT/StringMap.h"
+ #include "llvm/ADT/StringRef.h"
+ 
++#include <cstdint>
++
+ namespace mlir {
+ 
+ #define GEN_PASS_DECL_TOSATOSPIRVTOSAMARKGRAPHCONSTANTS
+@@ -55,6 +58,9 @@ void populateTosaToSPIRVTosaConversionPatterns(
+     spirv::TargetEnvAttr targetAttr);
+ void populateTosaToSPIRVTosaOpsConversionPatterns(
+     SPIRVTypeConverter &typeConverter, RewritePatternSet &patterns);
++void populateTosaToSPIRVTosaCustomConversionPatterns(
++    SPIRVTypeConverter &typeConverter, RewritePatternSet &patterns,
++    llvm::StringMap<int32_t> domainToOpcode);
+ 
+ } // namespace tosa
+ } // namespace mlir
+diff --git a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVExperimentalMLOps.td b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVExperimentalMLOps.td
+new file mode 100644
+index 000000000000..ddd478881958
+--- /dev/null
++++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVExperimentalMLOps.td
+@@ -0,0 +1,52 @@
++//===- SPIRVExperimentalMLOps.td - Experimental ML ops ------*- tablegen -*-===//
++//
++// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
++// See https://llvm.org/LICENSE.txt for license information.
++// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
++//
++//===----------------------------------------------------------------------===//
++
++#ifndef MLIR_DIALECT_SPIRV_IR_EXPERIMENTAL_ML_OPS
++#define MLIR_DIALECT_SPIRV_IR_EXPERIMENTAL_ML_OPS
++
++include "mlir/Dialect/SPIRV/IR/SPIRVBase.td"
++
++class SPIRV_ExperimentalMLOp<string mnemonic, int opcode,
++                             list<Trait> traits = []> :
++  SPIRV_ExtInstOp<mnemonic, "ExperimentalML", "Arm.ExperimentalMLOperations.1",
++                  opcode, traits> {
++  let availability = [
++    MinVersion<SPIRV_V_1_0>,
++    MaxVersion<SPIRV_V_1_6>,
++    Extension<[]>,
++    Capability<[]>
++  ];
++
++  let hasVerifier = 0;
++}
++
++def SPIRV_ExperimentalMLCallOp : SPIRV_ExperimentalMLOp<"Call", 0> {
++  let summary = "Call an Arm experimental ML operation.";
++
++  let description = [{
++    Calls an operation encoded using the Arm.ExperimentalMLOperations extended
++    instruction set. The `opcode` attribute is serialized as the operation
++    opcode literal integer operand of CALL.
++  }];
++
++  let arguments = (ins
++    I32Attr:$opcode,
++    Variadic<AnyType>:$parameters
++  );
++
++  let results = (outs
++    AnyType:$output
++  );
++
++  let assemblyFormat = [{
++    `opcode` `=` $opcode `,`
++    $parameters attr-dict `:` functional-type($parameters, $output)
++  }];
++}
++
++#endif // MLIR_DIALECT_SPIRV_IR_EXPERIMENTAL_ML_OPS
+diff --git a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVOps.td b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVOps.td
+index 3ef9699154cd..14dc76aef57d 100644
+--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVOps.td
++++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVOps.td
+@@ -30,6 +30,7 @@ include "mlir/Dialect/SPIRV/IR/SPIRVCastOps.td"
+ include "mlir/Dialect/SPIRV/IR/SPIRVCompositeOps.td"
+ include "mlir/Dialect/SPIRV/IR/SPIRVControlFlowOps.td"
+ include "mlir/Dialect/SPIRV/IR/SPIRVCooperativeMatrixOps.td"
++include "mlir/Dialect/SPIRV/IR/SPIRVExperimentalMLOps.td"
+ include "mlir/Dialect/SPIRV/IR/SPIRVIntelExtOps.td"
+ include "mlir/Dialect/SPIRV/IR/SPIRVGLOps.td"
+ include "mlir/Dialect/SPIRV/IR/SPIRVGraphOps.td"
+diff --git a/mlir/lib/Conversion/TosaToSPIRVTosa/CMakeLists.txt b/mlir/lib/Conversion/TosaToSPIRVTosa/CMakeLists.txt
+index ea59ba5f24cb..c4b71ed61f39 100644
+--- a/mlir/lib/Conversion/TosaToSPIRVTosa/CMakeLists.txt
++++ b/mlir/lib/Conversion/TosaToSPIRVTosa/CMakeLists.txt
+@@ -2,6 +2,7 @@ add_mlir_conversion_library(MLIRTosaToSPIRVTosa
+   TosaToSPIRVTosa.cpp
+   TosaToSPIRVTosaConstants.cpp
+   TosaToSPIRVTosaOps.cpp
++  TosaToSPIRVTosaCustom.cpp
+   TosaToSPIRVTosaPass.cpp
+ 
+   ADDITIONAL_HEADER_DIRS
+diff --git a/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosaCustom.cpp b/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosaCustom.cpp
+new file mode 100644
+index 000000000000..db97b97d5771
+--- /dev/null
++++ b/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosaCustom.cpp
+@@ -0,0 +1,107 @@
++//===- TosaToSPIRVTosaCustom.cpp - TOSA to SPIR-V Graph/TOSA patterns -----===//
++//
++// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
++// See https://llvm.org/LICENSE.txt for license information.
++// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
++//
++//===----------------------------------------------------------------------===//
++//
++// This file implements patterns to convert TOSA IR to SPIR-V Graph/TOSA.
++//
++//===----------------------------------------------------------------------===//
++
++#include "mlir/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosa.h"
++#include "mlir/Dialect/SPIRV/IR/SPIRVOps.h"
++#include "mlir/Dialect/Tosa/IR/TosaOps.h"
++#include "mlir/Transforms/DialectConversion.h"
++#include "llvm/ADT/STLExtras.h"
++#include "llvm/ADT/Sequence.h"
++
++#define DEBUG_TYPE "tosa-to-spirv-tosa-custom-pattern"
++
++namespace mlir::tosa {
++namespace {
++
++Value getI8ArrayConstant(StringRef value, Location loc,
++                         ConversionPatternRewriter &rewriter) {
++  auto i8Type = rewriter.getIntegerType(8);
++  // Empty strings are encoded as a single NUL byte because SPIR-V array
++  // types require at least one element.
++  StringRef encodedValue = value.empty() ? StringRef("\0", 1) : value;
++
++  SmallVector<Attribute> bytes;
++  bytes.reserve(encodedValue.size());
++  llvm::transform(
++      encodedValue, std::back_inserter(bytes),
++      [&](unsigned char byte) { return IntegerAttr::get(i8Type, byte); });
++
++  auto arrayType =
++      spirv::ArrayType::get(i8Type, static_cast<unsigned>(bytes.size()));
++  auto arrayValue = ArrayAttr::get(rewriter.getContext(), bytes);
++  return spirv::ConstantOp::create(rewriter, loc, arrayType, arrayValue);
++}
++
++struct TosaCustomOpConvert final : public OpConversionPattern<tosa::CustomOp> {
++  TosaCustomOpConvert(const TypeConverter &typeConverter, MLIRContext *context,
++                      llvm::StringMap<int32_t> domainToOpcode)
++      : OpConversionPattern<tosa::CustomOp>(typeConverter, context),
++        domainToOpcode(std::move(domainToOpcode)) {}
++
++  LogicalResult
++  matchAndRewrite(tosa::CustomOp op, tosa::CustomOpAdaptor adaptor,
++                  ConversionPatternRewriter &rewriter) const override {
++    auto opCode = domainToOpcode.find(op.getDomainName());
++    if (opCode == domainToOpcode.end())
++      return failure();
++
++    if (op->getResultTypes().empty())
++      return op.emitOpError("with mapped domain requires at least one result");
++
++    SmallVector<Type> types;
++    if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
++                                                      types)))
++      return rewriter.notifyMatchFailure(op, "type conversion failed");
++
++    Type resultType =
++        types.size() == 1 ? types.front() : spirv::StructType::get(types);
++
++    Value operatorName =
++        getI8ArrayConstant(op.getOperatorName(), op.getLoc(), rewriter);
++    Value implementationAttrsBlob =
++        getI8ArrayConstant(op.getImplementationAttrs(), op.getLoc(), rewriter);
++
++    SmallVector<Value> inputs = {operatorName, implementationAttrsBlob};
++    inputs.append(adaptor.getInputList().begin(), adaptor.getInputList().end());
++
++    Value result = spirv::ExperimentalMLCallOp::create(
++        rewriter, op.getLoc(), resultType,
++        rewriter.getI32IntegerAttr(opCode->second), inputs);
++
++    if (types.size() == 1) {
++      rewriter.replaceOp(op, result);
++      return success();
++    }
++
++    SmallVector<Value> results;
++    for (auto index : llvm::seq<int32_t>(0, types.size())) {
++      results.push_back(spirv::CompositeExtractOp::create(rewriter, op.getLoc(),
++                                                          result, {index}));
++    }
++    rewriter.replaceOp(op, results);
++    return success();
++  }
++
++private:
++  llvm::StringMap<int32_t> domainToOpcode;
++};
++
++} // namespace
++
++void populateTosaToSPIRVTosaCustomConversionPatterns(
++    SPIRVTypeConverter &typeConverter, RewritePatternSet &patterns,
++    llvm::StringMap<int32_t> domainToOpcode) {
++  patterns.add<TosaCustomOpConvert>(typeConverter, patterns.getContext(),
++                                    std::move(domainToOpcode));
++}
++
++} // namespace mlir::tosa
+diff --git a/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosaPass.cpp b/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosaPass.cpp
+index 3224cfe5f11c..abc1d5a4e2fc 100644
+--- a/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosaPass.cpp
++++ b/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosaPass.cpp
+@@ -19,8 +19,44 @@
+ #include "mlir/Dialect/Tosa/IR/TosaOps.h"
+ #include "mlir/IR/TypeUtilities.h"
+ #include "mlir/Transforms/DialectConversion.h"
++#include "llvm/ADT/StringMap.h"
++#include "llvm/ADT/StringRef.h"
++#include "llvm/Support/CommandLine.h"
+ 
+ #include <algorithm>
++#include <string>
++#include <utility>
++
++namespace llvm::cl {
++template <>
++class parser<std::pair<std::string, int32_t>>
++    : public basic_parser<std::pair<std::string, int32_t>> {
++public:
++  parser(Option &option) : basic_parser(option) {}
++
++  bool parse(Option &option, StringRef argName, StringRef arg,
++             std::pair<std::string, int32_t> &value) {
++    auto [domain, opcodeString] = arg.rsplit(":");
++    if (domain.empty() || opcodeString.empty())
++      return option.error("expected <domain>:<opcode>", argName);
++
++    int32_t opcode;
++    if (opcodeString.getAsInteger(0, opcode))
++      return option.error("invalid opcode in custom op domain mapping",
++                          argName);
++
++    value = {domain.str(), opcode};
++    return false;
++  }
++
++  StringRef getValueName() const override { return "domain:opcode"; }
++
++  static void print(raw_ostream &os,
++                    const std::pair<std::string, int32_t> &value) {
++    os << value.first << ":" << value.second;
++  }
++};
++} // namespace llvm::cl
+ 
+ namespace mlir {
+ #define GEN_PASS_DEF_TOSATOSPIRVTOSA
+@@ -126,10 +162,17 @@ LogicalResult verifyGraphConstantIdAttrs(Operation *op) {
  }
  
-+//===----------------------------------------------------------------------===//
-+// TosaToSPIRVTosa
-+//===----------------------------------------------------------------------===//
+ struct TosaToSPIRVTosa final : impl::TosaToSPIRVTosaBase<TosaToSPIRVTosa> {
 +
-+def TosaToSPIRVTosa : Pass<"tosa-to-spirv-tosa"> {
-+  let summary = "Lower TOSA IR to SPIR-V Graph/TOSA operations";
-+  let dependentDialects = [
-+    "spirv::SPIRVDialect",
-+  ];
-+  let description = [{
-+    Converts TOSA programs to the SPIR-V Graph/TOSA representation by
-+    wrapping converted functions in `spirv.module` and `spirv.ARM.Graph`
-+    operations, lowering supported TOSA ops to `spirv.Tosa.*`, and rewriting
-+    TOSA tensor and shape types to the corresponding SPIR-V ARM tensor types.
-+  }];
+   void runOnOperation() override {
+     MLIRContext *context = &getContext();
+     RewritePatternSet patterns(context);
+     Operation *op = getOperation();
++    llvm::StringMap<int32_t> domainToOpcode;
++    for (const auto &[domain, opcode] : customOpDomainToOpcode) {
++      // Allow later entries to override earlier ones, matching command-line
++      // option precedence when the same key is specified multiple times.
++      domainToOpcode[domain] = opcode;
++    }
+ 
+     spirv::TargetEnvAttr targetAttr = spirv::lookupTargetEnv(op);
+     if (!targetAttr) {
+@@ -164,6 +207,10 @@ struct TosaToSPIRVTosa final : impl::TosaToSPIRVTosaBase<TosaToSPIRVTosa> {
+                                               targetAttr);
+     populateTosaToSPIRVTosaOpsConversionPatterns(typeConverter, patterns);
+ 
++    if (!domainToOpcode.empty())
++      populateTosaToSPIRVTosaCustomConversionPatterns(
++          typeConverter, patterns, std::move(domainToOpcode));
 +
-+  let constructor = "tosa::createTosaToSPIRVTosa()";
-+}
-+
-+//===----------------------------------------------------------------------===//
-+// ConvertTosaConstantsPass
-+//===----------------------------------------------------------------------===//
-+
-+def ConvertTosaConstantsPass : Pass<"convert-tosa-constants-pass", "mlir::func::FuncOp"> {
-+  let summary = "Convert TOSA constants to SPIR-V graph constants";
-+
-+  let description = [{
-+    Pass that converts TOSA constants to SPIR-V graph constants in the
-+    SPIR-V dialect.
-+  }];
-+
-+  let constructor = "tosa::createConvertTosaConstantsPass()";
-+}
-+
- //===----------------------------------------------------------------------===//
- // TosaToTensor
- //===----------------------------------------------------------------------===//
-diff --git a/mlir/include/mlir/Conversion/TosaToSPIRVTosa/ConvertTosaConstants.h b/mlir/include/mlir/Conversion/TosaToSPIRVTosa/ConvertTosaConstants.h
+     FrozenRewritePatternSet frozenPatterns(std::move(patterns));
+ 
+     if (failed(applyPartialConversion(op, *target, frozenPatterns))) {
+diff --git a/mlir/test/Conversion/TosaToSPIRVTosa/custom-op-domain-to-opcode-invalid.mlir b/mlir/test/Conversion/TosaToSPIRVTosa/custom-op-domain-to-opcode-invalid.mlir
 new file mode 100644
-index 000000000000..be2838333f9b
+index 000000000000..e300603d4844
 --- /dev/null
-+++ b/mlir/include/mlir/Conversion/TosaToSPIRVTosa/ConvertTosaConstants.h
-@@ -0,0 +1,32 @@
-+//===-- ConvertTosaConstants.h - TOSA to SPIR-V graph constants --*- C++ -*-===//
-+//
-+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-+// See https://llvm.org/LICENSE.txt for license information.
-+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-+//
++++ b/mlir/test/Conversion/TosaToSPIRVTosa/custom-op-domain-to-opcode-invalid.mlir
+@@ -0,0 +1,7 @@
++// RUN: not mlir-opt --split-input-file --pass-pipeline='builtin.module(tosa-to-spirv-tosa{custom-op-domain-to-opcode=test:7})' %s 2>&1 | FileCheck %s
++
++func.func @zero_results(%arg0: tensor<1x16xf32>) {
++  // CHECK: 'tosa.custom' op with mapped domain requires at least one result
++  tosa.custom %arg0 {domain_name = "test", implementation_attrs = "{}", operator_name = "NoResult"} : (tensor<1x16xf32>) -> ()
++  return
++}
+diff --git a/mlir/test/Conversion/TosaToSPIRVTosa/custom-op-domain-to-opcode.mlir b/mlir/test/Conversion/TosaToSPIRVTosa/custom-op-domain-to-opcode.mlir
+new file mode 100644
+index 000000000000..b20b866d7eb5
+--- /dev/null
++++ b/mlir/test/Conversion/TosaToSPIRVTosa/custom-op-domain-to-opcode.mlir
+@@ -0,0 +1,42 @@
++// RUN: mlir-opt --split-input-file --pass-pipeline='builtin.module(tosa-to-spirv-tosa{custom-op-domain-to-opcode=my:custom:0,com.example.accel:42})' %s | FileCheck %s
++
 +//===----------------------------------------------------------------------===//
-+//
-+// Pass to convert TOSA constants to SPIR-V graph constants.
-+//
++// Mapped tosa.custom
 +//===----------------------------------------------------------------------===//
 +
-+#ifndef MLIR_CONVERSION_TOSATOSPIRVTOSA_CONVERTTOSACONSTANTS_H
-+#define MLIR_CONVERSION_TOSATOSPIRVTOSA_CONVERTTOSACONSTANTS_H
++// CHECK: spirv.module @_spirv_tosa_mapped_custom Logical Vulkan
++// CHECK: spirv.ARM.Graph @mapped_custom(%arg0: !spirv.arm.tensor<1x16xf32> {spirv.interface_var_abi = #spirv.interface_var_abi<(0, 0)>}, %arg1: !spirv.arm.tensor<1x16xf32> {spirv.interface_var_abi = #spirv.interface_var_abi<(0, 1)>}) -> (!spirv.arm.tensor<1x16xf32> {spirv.interface_var_abi = #spirv.interface_var_abi<(0, 2)>}) attributes {entry_point = true} {
++func.func @mapped_custom(%arg0: tensor<1x16xf32>, %arg1: tensor<1x16xf32>) -> tensor<1x16xf32> {
++  // CHECK: %[[OP_NAME:.*]] = spirv.Constant [84 : i8, 101 : i8, 115 : i8, 116 : i8, 79 : i8, 112 : i8] : !spirv.array<6 x i8>
++  // CHECK: %[[IMPLEMENTATION_ATTRS:.*]] = spirv.Constant [123 : i8, 34 : i8, 112 : i8, 97 : i8, 114 : i8, 97 : i8, 109 : i8, 34 : i8, 58 : i8, 34 : i8, 118 : i8, 97 : i8, 108 : i8, 117 : i8, 101 : i8, 34 : i8, 125 : i8] : !spirv.array<17 x i8>
++  // CHECK: %[[CALL:.*]] = spirv.ExperimentalML.Call opcode = 0, %[[OP_NAME]], %[[IMPLEMENTATION_ATTRS]], %arg0, %arg1 : (!spirv.array<6 x i8>, !spirv.array<17 x i8>, !spirv.arm.tensor<1x16xf32>, !spirv.arm.tensor<1x16xf32>) -> !spirv.arm.tensor<1x16xf32>
++  %0 = tosa.custom %arg0, %arg1 {domain_name = "my:custom", implementation_attrs = "{\"param\":\"value\"}", operator_name = "TestOp"} : (tensor<1x16xf32>, tensor<1x16xf32>) -> tensor<1x16xf32>
++  // CHECK: spirv.ARM.GraphOutputs %[[CALL]] : !spirv.arm.tensor<1x16xf32>
++  return %0 : tensor<1x16xf32>
++}
 +
-+#include "mlir/Dialect/Func/IR/FuncOps.h"
-+#include "mlir/Pass/Pass.h"
++// -----
 +
-+namespace mlir {
-+#define GEN_PASS_DEF_CONVERTTOSACONSTANTSPASS
-+#include "mlir/Conversion/Passes.h.inc"
++// CHECK: spirv.module @_spirv_tosa_other_custom Logical Vulkan
++// CHECK: spirv.ARM.Graph @other_custom(%arg0: !spirv.arm.tensor<1x16xf32> {spirv.interface_var_abi = #spirv.interface_var_abi<(0, 0)>}) -> (!spirv.arm.tensor<1x16xf32> {spirv.interface_var_abi = #spirv.interface_var_abi<(0, 1)>}) attributes {entry_point = true} {
++func.func @other_custom(%arg0: tensor<1x16xf32>) -> tensor<1x16xf32> {
++  // CHECK: %[[OP_NAME:.*]] = spirv.Constant [69 : i8, 120 : i8, 97 : i8, 109 : i8, 112 : i8, 108 : i8, 101 : i8, 79 : i8, 112 : i8] : !spirv.array<9 x i8>
++  // CHECK: %[[IMPLEMENTATION_ATTRS:.*]] = spirv.Constant [123 : i8, 125 : i8] : !spirv.array<2 x i8>
++  // CHECK: %[[CALL:.*]] = spirv.ExperimentalML.Call opcode = 42, %[[OP_NAME]], %[[IMPLEMENTATION_ATTRS]], %arg0 : (!spirv.array<9 x i8>, !spirv.array<2 x i8>, !spirv.arm.tensor<1x16xf32>) -> !spirv.arm.tensor<1x16xf32>
++  %0 = tosa.custom %arg0 {domain_name = "com.example.accel", implementation_attrs = "{}", operator_name = "ExampleOp"} : (tensor<1x16xf32>) -> tensor<1x16xf32>
++  // CHECK: spirv.ARM.GraphOutputs %[[CALL]] : !spirv.arm.tensor<1x16xf32>
++  return %0 : tensor<1x16xf32>
++}
 +
-+namespace tosa {
++// -----
 +
-+std::optional<uint32_t> getGraphIdForConst(Operation *op);
++// CHECK: spirv.module @_spirv_tosa_empty_strings Logical Vulkan
++// CHECK: spirv.ARM.Graph @empty_strings(%arg0: !spirv.arm.tensor<1x16xf32> {spirv.interface_var_abi = #spirv.interface_var_abi<(0, 0)>}) -> (!spirv.arm.tensor<1x16xf32> {spirv.interface_var_abi = #spirv.interface_var_abi<(0, 1)>}) attributes {entry_point = true} {
++func.func @empty_strings(%arg0: tensor<1x16xf32>) -> tensor<1x16xf32> {
++  // CHECK: %[[OP_NAME:.*]] = spirv.Constant [0 : i8] : !spirv.array<1 x i8>
++  // CHECK: %[[IMPLEMENTATION_ATTRS:.*]] = spirv.Constant [0 : i8] : !spirv.array<1 x i8>
++  // CHECK: %[[CALL:.*]] = spirv.ExperimentalML.Call opcode = 0, %[[OP_NAME]], %[[IMPLEMENTATION_ATTRS]], %arg0 : (!spirv.array<1 x i8>, !spirv.array<1 x i8>, !spirv.arm.tensor<1x16xf32>) -> !spirv.arm.tensor<1x16xf32>
++  %0 = tosa.custom %arg0 {domain_name = "my:custom", implementation_attrs = "", operator_name = ""} : (tensor<1x16xf32>) -> tensor<1x16xf32>
++  // CHECK: spirv.ARM.GraphOutputs %[[CALL]] : !spirv.arm.tensor<1x16xf32>
++  return %0 : tensor<1x16xf32>
++}
+diff --git a/mlir/test/Dialect/SPIRV/IR/experimental-ml-ops.mlir b/mlir/test/Dialect/SPIRV/IR/experimental-ml-ops.mlir
+new file mode 100644
+index 000000000000..caccb043d3af
+--- /dev/null
++++ b/mlir/test/Dialect/SPIRV/IR/experimental-ml-ops.mlir
+@@ -0,0 +1,14 @@
++// RUN: mlir-opt %s | FileCheck %s
 +
-+std::unique_ptr<Pass> createConvertTosaConstantsPass();
++//===----------------------------------------------------------------------===//
++// spirv.ExperimentalML.Call
++//===----------------------------------------------------------------------===//
 +
-+} // namespace tosa
-+} // namespace mlir
++spirv.ARM.Graph @experimental_ml_call(%arg0: !spirv.arm.tensor<1x16xf32>, %arg1: !spirv.arm.tensor<1x16xf32>) -> !spirv.arm.tensor<1x16xf32> {
++  // CHECK: %[[NAME:.*]] = spirv.Constant dense<[83, 101, 108, 102, 65, 116, 116, 101, 110, 116, 105, 111, 110, 79, 112]> : tensor<15xi8> : !spirv.array<15 x i8>
++  %name = spirv.Constant dense<[83, 101, 108, 102, 65, 116, 116, 101, 110, 116, 105, 111, 110, 79, 112]> : tensor<15xi8> : !spirv.array<15 x i8>
++  // CHECK: {{%.*}} = spirv.ExperimentalML.Call opcode = 0, %[[NAME]], %arg0, %arg1 : (!spirv.array<15 x i8>, !spirv.arm.tensor<1x16xf32>, !spirv.arm.tensor<1x16xf32>) -> !spirv.arm.tensor<1x16xf32>
++  %0 = spirv.ExperimentalML.Call opcode = 0, %name, %arg0, %arg1 : (!spirv.array<15 x i8>, !spirv.arm.tensor<1x16xf32>, !spirv.arm.tensor<1x16xf32>) -> !spirv.arm.tensor<1x16xf32>
++  // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<1x16xf32>
++  spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<1x16xf32>
++}
+diff --git a/mlir/test/Target/SPIRV/experimental-ml-ops.mlir b/mlir/test/Target/SPIRV/experimental-ml-ops.mlir
+new file mode 100644
+index 000000000000..5876f7339c33
+--- /dev/null
++++ b/mlir/test/Target/SPIRV/experimental-ml-ops.mlir
+@@ -0,0 +1,25 @@
++// RUN: mlir-translate --no-implicit-module --test-spirv-roundtrip %s | FileCheck %s
++// RUN: %if spirv-tools %{ mlir-translate --no-implicit-module --serialize-spirv %s | spirv-val %}
 +
-+#endif // MLIR_CONVERSION_TOSATOSPIRVTOSA_CONVERTTOSACONSTANTS_H
++// CHECK: spirv.module Logical Vulkan requires
++spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader, Int8, Float16, TensorsARM, GraphARM], [SPV_ARM_tensors, SPV_ARM_graph, SPV_KHR_vulkan_memory_model]> {
++  // CHECK: spirv.GlobalVariable @main_arg_0 bind(0, 0) : !spirv.ptr<!spirv.arm.tensor<1x16xf32>, UniformConstant>
++  spirv.GlobalVariable @main_arg_0 bind(0, 0) : !spirv.ptr<!spirv.arm.tensor<1x16xf32>, UniformConstant>
++  // CHECK: spirv.GlobalVariable @main_arg_1 bind(0, 1) : !spirv.ptr<!spirv.arm.tensor<1x16xf32>, UniformConstant>
++  spirv.GlobalVariable @main_arg_1 bind(0, 1) : !spirv.ptr<!spirv.arm.tensor<1x16xf32>, UniformConstant>
++  // CHECK: spirv.GlobalVariable @main_res_0 bind(0, 2) : !spirv.ptr<!spirv.arm.tensor<1x16xf32>, UniformConstant>
++  spirv.GlobalVariable @main_res_0 bind(0, 2) : !spirv.ptr<!spirv.arm.tensor<1x16xf32>, UniformConstant>
++  // CHECK: spirv.ARM.GraphEntryPoint @main, @main_arg_0, @main_arg_1, @main_res_0
++  spirv.ARM.GraphEntryPoint @main, @main_arg_0, @main_arg_1, @main_res_0
++  // CHECK: spirv.ARM.Graph @main(%arg0: !spirv.arm.tensor<1x16xf32>, %arg1: !spirv.arm.tensor<1x16xf32>) -> !spirv.arm.tensor<1x16xf32>
++  spirv.ARM.Graph @main(%arg0: !spirv.arm.tensor<1x16xf32>, %arg1: !spirv.arm.tensor<1x16xf32>) -> !spirv.arm.tensor<1x16xf32> {
++    // CHECK: %[[NAME:.*]] = spirv.Constant [83 : i8, 101 : i8, 108 : i8, 102 : i8, 65 : i8, 116 : i8, 116 : i8, 101 : i8, 110 : i8, 116 : i8, 105 : i8, 111 : i8, 110 : i8, 79 : i8, 112 : i8] : !spirv.array<15 x i8>
++    %name = spirv.Constant dense<[83, 101, 108, 102, 65, 116, 116, 101, 110, 116, 105, 111, 110, 79, 112]> : tensor<15xi8> : !spirv.array<15 x i8>
++    // CHECK: %[[ATTRS:.*]] = spirv.Constant [123 : i8, 34 : i8, 111 : i8, 112 : i8, 101 : i8, 114 : i8, 97 : i8, 116 : i8, 111 : i8, 114 : i8, 95 : i8, 110 : i8, 97 : i8, 109 : i8, 101 : i8, 34 : i8, 58 : i8, 34 : i8, 83 : i8, 101 : i8, 108 : i8, 102 : i8, 65 : i8, 116 : i8, 116 : i8, 101 : i8, 110 : i8, 116 : i8, 105 : i8, 111 : i8, 110 : i8, 79 : i8, 112 : i8, 34 : i8, 125 : i8] : !spirv.array<35 x i8>
++    %attrs = spirv.Constant dense<[123, 34, 111, 112, 101, 114, 97, 116, 111, 114, 95, 110, 97, 109, 101, 34, 58, 34, 83, 101, 108, 102, 65, 116, 116, 101, 110, 116, 105, 111, 110, 79, 112, 34, 125]> : tensor<35xi8> : !spirv.array<35 x i8>
++    // CHECK: %[[CALL:.*]] = spirv.ExperimentalML.Call opcode = 0, %[[NAME]], %[[ATTRS]], %arg0, %arg1 : (!spirv.array<15 x i8>, !spirv.array<35 x i8>, !spirv.arm.tensor<1x16xf32>, !spirv.arm.tensor<1x16xf32>) -> !spirv.arm.tensor<1x16xf32>
++    %0 = spirv.ExperimentalML.Call opcode = 0, %name, %attrs, %arg0, %arg1 : (!spirv.array<15 x i8>, !spirv.array<35 x i8>, !spirv.arm.tensor<1x16xf32>, !spirv.arm.tensor<1x16xf32>) -> !spirv.arm.tensor<1x16xf32>
++    // CHECK: spirv.ARM.GraphOutputs %[[CALL]] : !spirv.arm.tensor<1x16xf32>
++    spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<1x16xf32>
++  }
++}
+
+From 1f189c7516f04c8ad7d5eebbd4d9fe981c25423f Mon Sep 17 00:00:00 2001
+From: Davide Grohmann <davide.grohmann@arm.com>
+Date: Mon, 1 Jun 2026 13:47:17 +0200
+Subject: [PATCH] [mlir][spirv] Add TOSA to SPIR-V conversion analysis mode
+
+Restore the optional analysis mode for the TOSA to SPIR-V TOSA pass as
+a separate change.
+
+When enabled through the C++ pass factory, run applyAnalysisConversion
+before the real conversion and print the TOSA operations that are
+legalizable by the pass.
+
+Change-Id: I8c402f42f293b4e111e32aeae86f72e903c36b2b
+Signed-off-by: Davide Grohmann <davide.grohmann@arm.com>
+
 diff --git a/mlir/include/mlir/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosa.h b/mlir/include/mlir/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosa.h
-new file mode 100644
-index 000000000000..dede68df0392
---- /dev/null
+index 9a42cf75f187..ed56a4f58bb6 100644
+--- a/mlir/include/mlir/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosa.h
 +++ b/mlir/include/mlir/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosa.h
-@@ -0,0 +1,37 @@
-+//===-- TosaToSPIRVTosa.h - TOSA to SPIR-V Graph/TOSA patterns --*- C++ -*-===//
-+//
-+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-+// See https://llvm.org/LICENSE.txt for license information.
-+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-+//
-+//===----------------------------------------------------------------------===//
-+//
-+// Provides pass and patterns to lower TOSA IR to SPIR-V Graph/TOSA
-+// operations.
-+//
-+//===----------------------------------------------------------------------===//
-+
-+#ifndef MLIR_CONVERSION_TOSATOSPIRVTOSA_TOSATOSPIRVTOSA_H
-+#define MLIR_CONVERSION_TOSATOSPIRVTOSA_TOSATOSPIRVTOSA_H
-+
-+#include "mlir/Dialect/SPIRV/Transforms/SPIRVConversion.h"
-+#include "mlir/Pass/Pass.h"
-+
-+namespace mlir {
-+
-+#define GEN_PASS_DECL_TOSATOSPIRVTOSA
-+#include "mlir/Conversion/Passes.h.inc"
-+
-+namespace tosa {
-+
+@@ -42,7 +42,7 @@ constexpr llvm::StringLiteral graphARMGraphConstantIdAttrName =
+     "grapharm.graph_constant_id";
+ 
+ std::unique_ptr<Pass> createTosaToSPIRVTosaMarkGraphConstants();
+-std::unique_ptr<Pass> createTosaToSPIRVTosa();
 +std::unique_ptr<Pass> createTosaToSPIRVTosa(bool analysis = false);
-+
-+void populateTosaToSPIRVTosaConversionPatterns(
-+    SPIRVTypeConverter &typeConverter, RewritePatternSet &patterns);
-+void populateTosaToSPIRVTosaOpsConversionPatterns(
-+    SPIRVTypeConverter &typeConverter, RewritePatternSet &patterns);
-+
-+} // namespace tosa
-+} // namespace mlir
-+
-+#endif // MLIR_CONVERSION_TOSATOSPIRVTOSA_TOSATOSPIRVTOSA_H
-diff --git a/mlir/lib/Conversion/CMakeLists.txt b/mlir/lib/Conversion/CMakeLists.txt
-index e17988b12cad..f5e0bcf613e5 100644
---- a/mlir/lib/Conversion/CMakeLists.txt
-+++ b/mlir/lib/Conversion/CMakeLists.txt
-@@ -69,6 +69,7 @@ add_subdirectory(TosaToArith)
- add_subdirectory(TosaToLinalg)
- add_subdirectory(TosaToMLProgram)
- add_subdirectory(TosaToSCF)
-+add_subdirectory(TosaToSPIRVTosa)
- add_subdirectory(TosaToTensor)
- add_subdirectory(UBToLLVM)
- add_subdirectory(UBToSPIRV)
-diff --git a/mlir/lib/Conversion/TosaToSPIRVTosa/CMakeLists.txt b/mlir/lib/Conversion/TosaToSPIRVTosa/CMakeLists.txt
-new file mode 100644
-index 000000000000..e971c97a001b
---- /dev/null
-+++ b/mlir/lib/Conversion/TosaToSPIRVTosa/CMakeLists.txt
-@@ -0,0 +1,23 @@
-+add_mlir_conversion_library(MLIRTosaToSPIRVTosa
-+  TosaToSPIRVTosa.cpp
-+  TosaToSPIRVTosaOps.cpp
-+  TosaToSPIRVTosaPass.cpp
-+  ConvertTosaConstants.cpp
-+  # FIXME: Avoid linking a share lib by compiling in the single cpp file needed
-+  ${MLIR_MAIN_SRC_DIR}/lib/ExecutionEngine/Float16bits.cpp
-+
-+  ADDITIONAL_HEADER_DIRS
-+  ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Tosa
-+  ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
-+
-+  DEPENDS
-+  MLIRConversionPassIncGen
-+
-+  LINK_LIBS PUBLIC
-+  MLIRSPIRVDialect
-+  MLIRIR
-+  MLIRPass
-+  MLIRTosaDialect
-+  MLIRTosaTransforms
-+  MLIRSupport
-+)
-diff --git a/mlir/lib/Conversion/TosaToSPIRVTosa/ConvertTosaConstants.cpp b/mlir/lib/Conversion/TosaToSPIRVTosa/ConvertTosaConstants.cpp
-new file mode 100644
-index 000000000000..690771d3dd6e
---- /dev/null
-+++ b/mlir/lib/Conversion/TosaToSPIRVTosa/ConvertTosaConstants.cpp
-@@ -0,0 +1,209 @@
-+//===- ConvertTosaConstants.cpp - TOSA to SPIR-V graph constant pass ------===//
-+//
-+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-+// See https://llvm.org/LICENSE.txt for license information.
-+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-+//
-+//===----------------------------------------------------------------------===//
-+//
-+// This file implements a pass to convert TOSA constants to SPIR-V graph
-+// constants.
-+//
-+//===----------------------------------------------------------------------===//
-+
-+#include "mlir/Dialect/Func/IR/FuncOps.h"
-+#include "mlir/Dialect/Tosa/IR/TosaOps.h"
-+#include "mlir/Dialect/Tosa/Transforms/Passes.h"
-+#include "mlir/IR/TypeUtilities.h"
-+#include "mlir/Pass/Pass.h"
-+#include "mlir/Pass/PassManager.h"
-+
-+#include <unordered_map>
-+#include <vector>
-+
-+namespace mlir {
-+#define GEN_PASS_DEF_CONVERTTOSACONSTANTSPASS
-+#include "mlir/Conversion/Passes.h.inc"
-+
-+namespace tosa {
-+namespace {
-+
-+static constexpr uint32_t SPIRV_CONSTANT_MAX_SIZE_FOR_TOSA_CONST = 16;
-+static constexpr uint32_t SPIRV_CONSTANT_MAX_SIZE_FOR_TOSA_CONST_SHAPE = 32;
-+
-+static constexpr llvm::StringLiteral graphConstAttrName =
-+    "spirv_graph_constant_id";
-+
-+void setGraphIdForConst(Operation *op, uint32_t id) {
-+  const Type tI32 = IntegerType::get(op->getContext(), 32);
-+  op->setAttr(graphConstAttrName, IntegerAttr::get(tI32, id));
-+}
-+
-+bool isOpGraphConstantARM(Operation *op) {
-+  assert((isa<tosa::ConstOp>(op) || isa<tosa::ConstShapeOp>(op)) &&
-+         "Operation is not a tosa.const or tosa.const_shape");
-+
-+  ElementsAttr valueAttr;
-+  if (auto constOp = dyn_cast_or_null<tosa::ConstOp>(op)) {
-+    valueAttr = constOp.getValuesAttr();
-+  } else if (auto constShapeOp = dyn_cast_or_null<tosa::ConstShapeOp>(op)) {
-+    valueAttr = constShapeOp.getValuesAttr();
-+  }
-+
-+  assert(valueAttr && "Failed to get value attribute");
-+
-+  uint32_t constantSize = 0;
-+  if (auto elemAttr = dyn_cast_or_null<ElementsAttr>(valueAttr)) {
-+    constantSize = elemAttr.size();
-+  } else if (auto denseArrayAttr =
-+                 dyn_cast_or_null<DenseArrayAttr>(valueAttr)) {
-+    constantSize = denseArrayAttr.size();
-+  }
-+
-+  uint32_t maxSize = isa<tosa::ConstOp>(op)
-+                         ? SPIRV_CONSTANT_MAX_SIZE_FOR_TOSA_CONST
-+                         : SPIRV_CONSTANT_MAX_SIZE_FOR_TOSA_CONST_SHAPE;
-+
-+  return constantSize > maxSize;
-+}
-+
-+class OpInfo {
-+public:
-+  OpInfo(Operation &op, int32_t use_count) : _op(op), _use_count(use_count) {}
-+
-+  void addUseCount() { _use_count++; }
-+  int32_t getUseCount() const { return _use_count; }
-+  Operation &getOp() const { return _op; }
-+
-+private:
-+  Operation &_op;
-+  int32_t _use_count;
-+};
-+
-+class ConvertTosaConstantsPass
-+    : public impl::ConvertTosaConstantsPassBase<ConvertTosaConstantsPass> {
-+public:
-+  void runOnOperation() override {
-+    if (ConvertTosaConstants(getOperation()).failed()) {
-+      signalPassFailure();
-+    }
-+  }
-+
-+private:
-+  using HandleType = size_t;
-+
-+  HandleType getOpHandle(Operation &op) {
-+    return llvm::hash_combine_range(op.result_begin(), op.result_end());
-+  }
-+
-+  bool hasOpInfo(HandleType handle) {
-+    return _operations_map.count(handle) != 0;
-+  }
-+
-+  OpInfo &getOpInfo(HandleType handle) {
-+    return _operations[_operations_map.at(handle)];
-+  }
-+
-+  void insertOpInfo(HandleType handle, Operation &op, int32_t use_count = 0) {
-+    assert(!hasOpInfo(handle));
-+    _operations_map.emplace(handle, _operations.size());
-+    _operations.emplace_back(OpInfo(op, use_count));
-+  }
-+
-+  HandleType getAttrHandle(Attribute &attr) { return hash_value(attr); }
-+
-+  bool hasAttrId(HandleType handle) {
-+    return _attributes_map.count(handle) != 0;
-+  }
-+
-+  uint32_t getAttrId(HandleType handle) { return _attributes_map.at(handle); }
-+
-+  void insertAttrId(HandleType handle, uint32_t attr_id) {
-+    _attributes_map.emplace(handle, attr_id);
-+  }
-+
-+  uint32_t getOrInsertAttrId(HandleType handle) {
-+    if (!hasAttrId(handle)) {
-+      insertAttrId(handle, _next_const_id++);
-+    }
-+    return getAttrId(handle);
-+  }
-+
-+  LogicalResult ConvertTosaConstants(func::FuncOp);
-+
-+  std::unordered_map<HandleType, uint32_t> _attributes_map;
-+  std::unordered_map<HandleType, size_t> _operations_map;
-+  std::vector<OpInfo> _operations;
-+
-+  uint32_t _next_const_id = 0;
-+};
-+
-+LogicalResult
-+ConvertTosaConstantsPass::ConvertTosaConstants(func::FuncOp func) {
-+  HandleType handle;
-+
-+  auto &region = func.getRegion();
-+  if (!region.hasOneBlock()) {
-+    return func.emitError("Invalid MLIR: multiple blocks in a region");
-+  }
-+
-+  auto &block = region.front();
-+  if (!block.isEntryBlock()) {
-+    return func.emitError("Invalid MLIR: first block is not an entry block");
-+  }
-+
-+  for (auto &op : block) {
-+    // Register a tosa.const or tosa.const_shape op in the op map with inital
-+    // use count of 0. Use count is incremented when an op uses this const as an
-+    // operand.
-+    if (llvm::isa<tosa::ConstOp>(op) || llvm::isa<tosa::ConstShapeOp>(op)) {
-+      handle = getOpHandle(op);
-+      insertOpInfo(handle, op, 0);
-+      continue;
-+    }
-+
-+    // For each operation, check if any operand is a tosa.const or
-+    // tosa.const_shape and increment use count of its map entry.
-+    for (auto &operand : op.getOpOperands()) {
-+      if (auto definingOp = operand.get().getDefiningOp()) {
-+        // Operand defining op is not tosa.const or tosa.const
-+        if (!llvm::isa<tosa::ConstOp>(*definingOp) &&
-+            !llvm::isa<tosa::ConstShapeOp>(*definingOp))
-+          continue;
-+
-+        getOpInfo(getOpHandle(*definingOp)).addUseCount();
-+      }
-+    }
-+  }
-+
-+  for (auto &opInfo : _operations) {
-+    if (!opInfo.getUseCount())
-+      continue;
-+
-+    auto &op = opInfo.getOp();
-+    if (!isOpGraphConstantARM(&op))
-+      continue;
-+
-+    // Assign graph constant IDs to tosa.const or tosa.const_shape ops having a
-+    // non zero use count.
-+    setGraphIdForConst(&op, _next_const_id++);
-+  }
-+
-+  return success();
-+}
-+
-+} // namespace
-+
-+std::optional<uint32_t> getGraphIdForConst(Operation *op) {
-+  if (auto attr = op->getAttrOfType<IntegerAttr>(graphConstAttrName)) {
-+    return static_cast<uint32_t>(attr.getInt());
-+  }
-+  return std::nullopt;
-+}
-+
-+std::unique_ptr<Pass> createConvertTosaConstantsPass() {
-+  return std::make_unique<ConvertTosaConstantsPass>();
-+}
-+
-+} // namespace tosa
-+} // namespace mlir
-diff --git a/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosa.cpp b/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosa.cpp
-new file mode 100644
-index 000000000000..b43a50389cf5
---- /dev/null
-+++ b/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosa.cpp
-@@ -0,0 +1,168 @@
-+//===- TosaToSPIRVTosa.cpp - TOSA to SPIR-V Graph/TOSA patterns -----------===//
-+//
-+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-+// See https://llvm.org/LICENSE.txt for license information.
-+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-+//
-+//===----------------------------------------------------------------------===//
-+//
-+// This file implements patterns to convert TOSA IR to SPIR-V Graph/TOSA.
-+//
-+//===----------------------------------------------------------------------===//
-+
-+#include "mlir/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosa.h"
-+#include "mlir/Dialect/Func/IR/FuncOps.h"
-+#include "mlir/Dialect/SPIRV/IR/SPIRVDialect.h"
-+#include "mlir/Dialect/SPIRV/IR/SPIRVOps.h"
-+#include "mlir/IR/Matchers.h"
-+#include "mlir/IR/TypeUtilities.h"
-+#include "mlir/Transforms/DialectConversion.h"
-+#include "llvm/ADT/ArrayRef.h"
-+#include "llvm/Support/FormatVariadic.h"
-+
-+#include "TosaToSPIRVTosaBasePattern.h"
-+
-+#define DEBUG_TYPE "tosa-to-spirv-tosa-pattern"
-+
-+namespace mlir {
-+namespace tosa {
-+namespace {
-+
-+constexpr StringLiteral graphARMInterfaceVarABIAttrName =
-+    "spv.grapharm.interface_var_abi";
-+
-+struct FuncGraphConvert final : public TosaOpConversionPattern<func::FuncOp> {
-+  using TosaOpConversionPattern<func::FuncOp>::TosaOpConversionPattern;
-+
-+private:
-+  void setInterfaceVarABIAttr(spirv::GraphARMOp graphOp, MLIRContext *context,
-+                              unsigned index, bool isResult,
-+                              uint32_t defaultDescriptorSet,
-+                              uint32_t defaultBinding) const {
-+    auto abiInfo =
-+        isResult ? graphOp.getResultAttrOfType<spirv::InterfaceVarABIAttr>(
-+                       index, graphARMInterfaceVarABIAttrName)
-+                 : graphOp.getArgAttrOfType<spirv::InterfaceVarABIAttr>(
-+                       index, graphARMInterfaceVarABIAttrName);
-+
-+    if (!abiInfo) {
-+      abiInfo = isResult
-+                    ? graphOp.getResultAttrOfType<spirv::InterfaceVarABIAttr>(
-+                          index, spirv::getInterfaceVarABIAttrName())
-+                    : graphOp.getArgAttrOfType<spirv::InterfaceVarABIAttr>(
-+                          index, spirv::getInterfaceVarABIAttrName());
-+    }
-+
-+    if (!abiInfo) {
-+      abiInfo = spirv::InterfaceVarABIAttr::get(
-+          defaultDescriptorSet, defaultBinding, std::nullopt, context);
-+    }
-+
-+    if (isResult) {
-+      graphOp.setResultAttr(index, spirv::getInterfaceVarABIAttrName(),
-+                            abiInfo);
-+      graphOp.removeResultAttr(index, graphARMInterfaceVarABIAttrName);
-+    } else {
-+      graphOp.setArgAttr(index, spirv::getInterfaceVarABIAttrName(), abiInfo);
-+      graphOp.removeArgAttr(index, graphARMInterfaceVarABIAttrName);
-+    }
-+  }
-+
-+public:
-+  LogicalResult
-+  matchAndRewrite(func::FuncOp funcOp, func::FuncOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+    MLIRContext *context = rewriter.getContext();
-+
-+    StringRef name = adaptor.getSymName();
-+
-+    bool entryPoint = !isa<func::FuncOp>(funcOp->getParentOp());
-+    if (entryPoint) {
-+      auto spvModule = spirv::ModuleOp::create(
-+          rewriter, funcOp.getLoc(), spirv::AddressingModel::Logical,
-+          spirv::MemoryModel::Vulkan, std::nullopt,
-+          ("_spirv_tosa_" + name).str());
-+
-+      rewriter.setInsertionPoint(spvModule.getBody(), spvModule.begin());
-+    }
-+
-+    FunctionType ftype = adaptor.getFunctionType();
-+    ArrayAttr argAttrs = adaptor.getArgAttrsAttr();
-+    ArrayAttr resAttrs = adaptor.getResAttrsAttr();
-+
-+    TypeConverter::SignatureConversion signatureConverter(ftype.getNumInputs());
-+    if (failed(typeConverter->convertSignatureArgs(ftype.getInputs(),
-+                                                   signatureConverter))) {
-+      return funcOp.emitError("failed to convert function argument types");
-+    }
-+
-+    // Update the signature of the function.
-+    SmallVector<Type, 2> newResultTypes;
-+    if (failed(getTypeConverter()->convertTypes(ftype.getResults(),
-+                                                newResultTypes))) {
-+      return funcOp.emitError("failed to convert function result types");
-+    }
-+
-+    auto graphTy = GraphType::get(
-+        context, signatureConverter.getConvertedTypes(), newResultTypes);
-+    auto entryPointAttr = BoolAttr::get(context, entryPoint);
-+    auto graphOp =
-+        spirv::GraphARMOp::create(rewriter, funcOp.getLoc(), graphTy, argAttrs,
-+                                  resAttrs, entryPointAttr, name);
-+    graphOp->setAttrs(adaptor.getAttributes());
-+    rewriter.inlineRegionBefore(funcOp.getBody(), graphOp.getBody(),
-+                                graphOp.end());
-+    if (failed(rewriter.convertRegionTypes(
-+            &graphOp.getBody(), *getTypeConverter(), &signatureConverter))) {
-+      return funcOp.emitError("failed to convert function regions");
-+    }
-+
-+    if (entryPoint) {
-+      uint32_t descriptorSet = 0;
-+      if (auto descriptorSetAttr =
-+              funcOp->getAttrOfType<IntegerAttr>("descriptor_set")) {
-+        descriptorSet = static_cast<uint32_t>(descriptorSetAttr.getUInt());
-+      }
-+
-+      unsigned inputs = ftype.getNumInputs();
-+      unsigned outputs = ftype.getNumResults();
-+
-+      for (auto argIndex : llvm::seq<unsigned>(0, inputs)) {
-+        setInterfaceVarABIAttr(graphOp, context, argIndex, false, descriptorSet,
-+                               argIndex);
-+      }
-+      for (auto resIndex : llvm::seq<unsigned>(0, outputs)) {
-+        setInterfaceVarABIAttr(graphOp, context, resIndex, true, descriptorSet,
-+                               resIndex + inputs);
-+      }
-+    }
-+
-+    rewriter.eraseOp(funcOp);
-+    return success();
-+  }
-+};
-+
-+/// Converts func.return to spirv.Return.
-+class ReturnGraphOutputConvert final
-+    : public TosaOpConversionPattern<func::ReturnOp> {
-+  using TosaOpConversionPattern<func::ReturnOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(func::ReturnOp returnOp, OpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+    rewriter.replaceOpWithNewOp<spirv::GraphOutputsARMOp>(
-+        returnOp, adaptor.getOperands());
-+    return success();
-+  }
-+};
-+
-+} // namespace
-+
-+void populateTosaToSPIRVTosaConversionPatterns(
-+    SPIRVTypeConverter &typeConverter, RewritePatternSet &patterns) {
-+  patterns.add<FuncGraphConvert, ReturnGraphOutputConvert>(
-+      typeConverter, patterns.getContext());
-+}
-+
-+} // namespace tosa
-+} // namespace mlir
-diff --git a/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosaBasePattern.h b/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosaBasePattern.h
-new file mode 100644
-index 000000000000..e5a9a05a697e
---- /dev/null
-+++ b/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosaBasePattern.h
-@@ -0,0 +1,141 @@
-+//===-- TosaToSPIRVTosaBasePattern.h - TOSA to SPIR-V Graph/TOSA patterns --*- C++ -*-===//
-+//
-+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-+// See https://llvm.org/LICENSE.txt for license information.
-+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-+//
-+//===----------------------------------------------------------------------===//
-+//
-+// Provides base patterns to convert TOSA IR to SPIR-V Graph/TOSA.
-+//
-+//===----------------------------------------------------------------------===//
-+
-+#ifndef MLIR_CONVERSION_TOSATOSPIRVTOSA_TOSATOSPIRVTOSABASEPATTERN_H
-+#define MLIR_CONVERSION_TOSATOSPIRVTOSA_TOSATOSPIRVTOSABASEPATTERN_H
-+
-+#include "mlir/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosa.h"
-+#include "mlir/Dialect/SPIRV/IR/SPIRVEnums.h"
-+#include "mlir/Dialect/Tosa/IR/TosaOps.h"
-+#include "mlir/ExecutionEngine/Float16bits.h"
-+#include "mlir/IR/TypeUtilities.h"
-+#include "mlir/Transforms/DialectConversion.h"
-+
-+namespace mlir {
-+namespace tosa {
-+
-+static constexpr unsigned MAX_CONTACT_OP_INPUTS = 64;
-+
-+template <typename SourceOp>
-+struct TosaOpConversionPattern : public OpConversionPattern<SourceOp> {
-+  using OpConversionPattern<SourceOp>::OpConversionPattern;
-+
-+  TosaOpConversionPattern(SPIRVTypeConverter &typeConverter,
-+                          MLIRContext *context)
-+      : OpConversionPattern<SourceOp>::OpConversionPattern(typeConverter,
-+                                                           context) {}
-+
-+  Type convertType(Type type) const {
-+    return this->getTypeConverter()->convertType(type);
-+  }
-+
-+  Type getConvertedElementType(Value type) const {
-+    return this->getTypeConverter()->convertType(getElementTypeOrSelf(type));
-+  }
-+
-+  spirv::TosaExtAccType convertAccType(Type accType) const {
-+    if (accType.isInteger(32))
-+      return spirv::TosaExtAccType::INT32;
-+    if (accType.isF16())
-+      return spirv::TosaExtAccType::FP16;
-+    if (accType.isF32())
-+      return spirv::TosaExtAccType::FP32;
-+    if (accType.isInteger(48))
-+      return spirv::TosaExtAccType::INT48;
-+    llvm_unreachable("Unknown accumulator type");
-+  }
-+
-+  LogicalResult maybeConvertValue(Location loc, ElementsAttr value,
-+                                  ElementsAttr &out) const {
-+    const ShapedType type = value.getShapedType();
-+    const ShapedType convertedType =
-+        llvm::dyn_cast_or_null<ShapedType>(convertType(type));
-+    if (convertedType == nullptr) {
-+      return emitError(
-+          loc, "type conversion did not produce the expected shaped type");
-+    }
-+
-+    // if types are the same, nothing to do here
-+    if (type == convertedType) {
-+      out = value;
-+      return success();
-+    }
-+
-+    const auto attr = llvm::dyn_cast_or_null<DenseElementsAttr>(value);
-+    if (attr == nullptr) {
-+      return emitError(
-+          loc, "the attribute is not of the expected dense element attr type");
-+    }
-+
-+    DenseElementsAttr convertedAttr = attr;
-+    // if element types are not the same, convert the elements
-+    if (getElementTypeOrSelf(type) != getElementTypeOrSelf(convertedType)) {
-+      // type conversion is supposed to be done only for integers
-+      const IntegerType intType = llvm::dyn_cast_or_null<IntegerType>(
-+          getElementTypeOrSelf(convertedType));
-+      if (intType == nullptr) {
-+        return emitError(
-+            loc, "converted element type is expected to be an integet type");
-+      }
-+
-+      // do the conversion
-+      if (convertedAttr.empty() && getElementTypeOrSelf(type).isIndex()) {
-+        // special case for converting tensor<0xindex> to
-+        // !spirv.arm.tensor<1xi32>
-+        convertedAttr = DenseIntElementsAttr::get(convertedType, {1});
-+      } else {
-+        convertedAttr = attr.mapValues(intType, [&](const APInt &value) {
-+          return value.sextOrTrunc(intType.getWidth());
-+        });
-+      }
-+    }
-+
-+    // reshape if needed (for example from rank 0 to rank 1 dim [1])
-+    out = convertedAttr.reshape(convertedType);
-+    return success();
-+  }
-+
-+  void splitConcat(tosa::ConcatOp op, int64_t axisDimIndex,
-+                   uint32_t axisValue, ValueRange inputs,
-+                   ShapedType inputType,
-+                   ConversionPatternRewriter &rewriter) const {
-+
-+    ArrayRef<int64_t> shape = inputType.getShape();
-+    size_t numInputs = inputs.getTypes().size();
-+    int64_t axisDim = shape[axisDimIndex];
-+
-+    SmallVector<int64_t, 6> newShape(shape.begin(), shape.end());
-+    newShape[axisDimIndex] = 0;
-+    SmallVector<Value, MAX_CONTACT_OP_INPUTS> values;
-+    spirv::TosaConcatOp newOp;
-+    for (const auto &[index, value] : llvm::enumerate(inputs)) {
-+      values.emplace_back(value);
-+      newShape[axisDimIndex] += axisDim;
-+      if (/* is last? */ index == numInputs - 1) {
-+        Type newType = convertType(inputType.clone(newShape));
-+        newOp = rewriter.replaceOpWithNewOp<spirv::TosaConcatOp>(
-+            op, newType, axisValue, values);
-+      } else if (values.size() % MAX_CONTACT_OP_INPUTS == 0) {
-+        Type newType = convertType(inputType.clone(newShape));
-+        newOp = spirv::TosaConcatOp::create(rewriter, op->getLoc(), newType,
-+                                            axisValue, values);
-+        values.clear();
-+        values.emplace_back(newOp.getOutput());
-+      }
-+    }
-+  }
-+};
-+
-+} // namespace tosa
-+} // namespace mlir
-+
-+#endif // MLIR_CONVERSION_TOSATOSPIRVTOSA_TOSATOSPIRVTOSABASEPATTERN_H
-diff --git a/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosaOps.cpp b/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosaOps.cpp
-new file mode 100644
-index 000000000000..c95ec7a0f55f
---- /dev/null
-+++ b/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosaOps.cpp
-@@ -0,0 +1,1285 @@
-+//===- TosaToSPIRVTosaOps.cpp - TOSA to SPIR-V Graph/TOSA patterns --------===//
-+//
-+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-+// See https://llvm.org/LICENSE.txt for license information.
-+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-+//
-+//===----------------------------------------------------------------------===//
-+//
-+// This file implements patterns to convert TOSA IR to SPIR-V Graph/TOSA.
-+//
-+//===----------------------------------------------------------------------===//
-+
-+#include "mlir/Conversion/TosaToSPIRVTosa/ConvertTosaConstants.h"
-+#include "mlir/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosa.h"
-+#include "mlir/Dialect/SPIRV/IR/SPIRVDialect.h"
-+#include "mlir/Dialect/SPIRV/IR/SPIRVOps.h"
-+#include "mlir/Dialect/SPIRV/IR/SPIRVTypes.h"
-+#include "mlir/Dialect/Tosa/IR/TosaOps.h"
-+#include "mlir/IR/Matchers.h"
-+#include "mlir/Transforms/DialectConversion.h"
-+#include "llvm/ADT/ArrayRef.h"
-+#include "llvm/Support/FormatVariadic.h"
-+
-+#include "TosaToSPIRVTosaBasePattern.h"
-+
-+#define DEBUG_TYPE "tosa-to-spirv-tosa-ops-pattern"
-+
-+namespace mlir {
-+namespace tosa {
-+namespace {
-+
-+DenseIntElementsAttr getI32TensorArmAttr(ArrayRef<int32_t> values,
-+                                         ConversionPatternRewriter &rewriter) {
-+  return DenseIntElementsAttr::get(
-+      spirv::TensorArmType::get(static_cast<int64_t>(values.size()),
-+                                IntegerType::get(rewriter.getContext(), 32)),
-+      values);
-+}
-+
-+struct TosaArgMaxConvert final
-+    : public TosaOpConversionPattern<tosa::ArgMaxOp> {
-+  using TosaOpConversionPattern<tosa::ArgMaxOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::ArgMaxOp op, tosa::ArgMaxOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+    auto axis = adaptor.getAxis();
-+    auto nanMode =
-+        static_cast<spirv::TosaExtNaNPropagationModeType>(adaptor.getNanMode());
-+    Value input = adaptor.getInput();
-+    rewriter.replaceOpWithNewOp<spirv::TosaArgMaxOp>(
-+        op, convertType(op.getType()), axis, nanMode, input);
-+    return success();
-+  }
-+};
-+
-+struct TosaAvgPool2DConvert final
-+    : public TosaOpConversionPattern<tosa::AvgPool2dOp> {
-+  using TosaOpConversionPattern<tosa::AvgPool2dOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::AvgPool2dOp op, tosa::AvgPool2dOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+    DenseIntElementsAttr kernel = getI32TensorArmAttr(
-+        SmallVector<int32_t>(adaptor.getKernel()), rewriter);
-+    DenseIntElementsAttr stride = getI32TensorArmAttr(
-+        SmallVector<int32_t>(adaptor.getStride()), rewriter);
-+    DenseIntElementsAttr pad =
-+        getI32TensorArmAttr(SmallVector<int32_t>(adaptor.getPad()), rewriter);
-+    auto accType = convertAccType(adaptor.getAccType());
-+    Value input = adaptor.getInput();
-+    Value inputZp = adaptor.getInputZp();
-+    Value outputZp = adaptor.getOutputZp();
-+    rewriter.replaceOpWithNewOp<spirv::TosaAvgPool2DOp>(
-+        op, convertType(op.getType()), kernel, stride, pad, accType, input,
-+        inputZp, outputZp);
-+    return success();
-+  }
-+};
-+
-+struct TosaConv2DConvert final
-+    : public TosaOpConversionPattern<tosa::Conv2DOp> {
-+  using TosaOpConversionPattern<tosa::Conv2DOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::Conv2DOp op, tosa::Conv2DOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+    DenseIntElementsAttr pad =
-+        getI32TensorArmAttr(SmallVector<int32_t>(adaptor.getPad()), rewriter);
-+    DenseIntElementsAttr stride = getI32TensorArmAttr(
-+        SmallVector<int32_t>(adaptor.getStride()), rewriter);
-+    DenseIntElementsAttr dilation = getI32TensorArmAttr(
-+        SmallVector<int32_t>(adaptor.getDilation()), rewriter);
-+    auto accType = convertAccType(adaptor.getAccType());
-+    auto localBound = adaptor.getLocalBound();
-+    Value input = adaptor.getInput();
-+    Value weight = adaptor.getWeight();
-+    Value bias = adaptor.getBias();
-+    Value inputZp = adaptor.getInputZp();
-+    Value weightZp = adaptor.getWeightZp();
-+    rewriter.replaceOpWithNewOp<spirv::TosaConv2DOp>(
-+        op, convertType(op.getType()), pad, stride, dilation, accType,
-+        localBound, input, weight, bias, inputZp, weightZp);
-+    return success();
-+  }
-+};
-+
-+struct TosaConv3DConvert final
-+    : public TosaOpConversionPattern<tosa::Conv3DOp> {
-+  using TosaOpConversionPattern<tosa::Conv3DOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::Conv3DOp op, tosa::Conv3DOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+    DenseIntElementsAttr pad =
-+        getI32TensorArmAttr(SmallVector<int32_t>(adaptor.getPad()), rewriter);
-+    DenseIntElementsAttr stride = getI32TensorArmAttr(
-+        SmallVector<int32_t>(adaptor.getStride()), rewriter);
-+    DenseIntElementsAttr dilation = getI32TensorArmAttr(
-+        SmallVector<int32_t>(adaptor.getDilation()), rewriter);
-+    auto accType = convertAccType(adaptor.getAccType());
-+    auto localBound = adaptor.getLocalBound();
-+    Value input = adaptor.getInput();
-+    Value weight = adaptor.getWeight();
-+    Value bias = adaptor.getBias();
-+    Value inputZp = adaptor.getInputZp();
-+    Value weightZp = adaptor.getWeightZp();
-+    rewriter.replaceOpWithNewOp<spirv::TosaConv3DOp>(
-+        op, convertType(op.getType()), pad, stride, dilation, accType,
-+        localBound, input, weight, bias, inputZp, weightZp);
-+    return success();
-+  }
-+};
-+
-+struct TosaDepthwiseConv2DConvert final
-+    : public TosaOpConversionPattern<tosa::DepthwiseConv2DOp> {
-+  using TosaOpConversionPattern<
-+      tosa::DepthwiseConv2DOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::DepthwiseConv2DOp op,
-+                  tosa::DepthwiseConv2DOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+    DenseIntElementsAttr pad =
-+        getI32TensorArmAttr(SmallVector<int32_t>(adaptor.getPad()), rewriter);
-+    DenseIntElementsAttr stride = getI32TensorArmAttr(
-+        SmallVector<int32_t>(adaptor.getStride()), rewriter);
-+    DenseIntElementsAttr dilation = getI32TensorArmAttr(
-+        SmallVector<int32_t>(adaptor.getDilation()), rewriter);
-+    auto accType = convertAccType(adaptor.getAccType());
-+    auto localBound = adaptor.getLocalBound();
-+    Value input = adaptor.getInput();
-+    Value weight = adaptor.getWeight();
-+    Value bias = adaptor.getBias();
-+    Value inputZp = adaptor.getInputZp();
-+    Value weightZp = adaptor.getWeightZp();
-+    rewriter.replaceOpWithNewOp<spirv::TosaDepthwiseConv2DOp>(
-+        op, convertType(op.getType()), pad, stride, dilation, accType,
-+        localBound, input, weight, bias, inputZp, weightZp);
-+    return success();
-+  }
-+};
-+
-+struct TosaFFT2DConvert final : public TosaOpConversionPattern<tosa::FFT2dOp> {
-+  using TosaOpConversionPattern<tosa::FFT2dOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::FFT2dOp op, tosa::FFT2dOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+    auto inverse = adaptor.getInverse();
-+    auto localBound = adaptor.getLocalBound();
-+    Value inputReal = adaptor.getInputReal();
-+    Value inputImag = adaptor.getInputImag();
-+    spirv::StructType structType = spirv::StructType::get(
-+        {convertType(op.getType(0)), convertType(op.getType(1))});
-+
-+    Value result =
-+        spirv::TosaFFT2DOp::create(rewriter, op->getLoc(), structType, inverse,
-+                                   localBound, inputReal, inputImag);
-+
-+    Value outputReal = spirv::CompositeExtractOp::create(
-+        rewriter, op->getLoc(), result, llvm::ArrayRef(0));
-+    Value outputImag = spirv::CompositeExtractOp::create(
-+        rewriter, op->getLoc(), result, llvm::ArrayRef(1));
-+
-+    rewriter.replaceOp(op, {outputReal, outputImag});
-+
-+    return success();
-+  }
-+};
-+
-+struct TosaMatMulConvert final
-+    : public TosaOpConversionPattern<tosa::MatMulOp> {
-+  using TosaOpConversionPattern<tosa::MatMulOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::MatMulOp op, tosa::MatMulOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value A = adaptor.getA();
-+    Value B = adaptor.getB();
-+    Value AZp = adaptor.getAZp();
-+    Value BZp = adaptor.getBZp();
-+    rewriter.replaceOpWithNewOp<spirv::TosaMatMulOp>(
-+        op, convertType(op.getType()), A, B, AZp, BZp);
-+    return success();
-+  }
-+};
-+
-+struct TosaMaxPool2DConvert final
-+    : public TosaOpConversionPattern<tosa::MaxPool2dOp> {
-+  using TosaOpConversionPattern<tosa::MaxPool2dOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::MaxPool2dOp op, tosa::MaxPool2dOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+    DenseIntElementsAttr kernel = getI32TensorArmAttr(
-+        SmallVector<int32_t>(adaptor.getKernel()), rewriter);
-+    DenseIntElementsAttr stride = getI32TensorArmAttr(
-+        SmallVector<int32_t>(adaptor.getStride()), rewriter);
-+    DenseIntElementsAttr pad =
-+        getI32TensorArmAttr(SmallVector<int32_t>(adaptor.getPad()), rewriter);
-+    auto nanMode =
-+        static_cast<spirv::TosaExtNaNPropagationModeType>(adaptor.getNanMode());
-+    Value input = adaptor.getInput();
-+    rewriter.replaceOpWithNewOp<spirv::TosaMaxPool2DOp>(
-+        op, convertType(op.getType()), kernel, stride, pad, nanMode, input);
-+    return success();
-+  }
-+};
-+
-+struct TosaRFFT2DConvert final
-+    : public TosaOpConversionPattern<tosa::RFFT2dOp> {
-+  using TosaOpConversionPattern<tosa::RFFT2dOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::RFFT2dOp op, tosa::RFFT2dOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+    auto localBound = adaptor.getLocalBound();
-+    Value inputReal = adaptor.getInputReal();
-+    spirv::StructType structType = spirv::StructType::get(
-+        {convertType(op.getType(0)), convertType(op.getType(1))});
-+
-+    Value result = spirv::TosaRFFT2DOp::create(
-+        rewriter, op->getLoc(), structType, localBound, inputReal);
-+
-+    Value outputReal = spirv::CompositeExtractOp::create(
-+        rewriter, op->getLoc(), result, llvm::ArrayRef(0));
-+    Value outputImag = spirv::CompositeExtractOp::create(
-+        rewriter, op->getLoc(), result, llvm::ArrayRef(1));
-+
-+    rewriter.replaceOp(op, {outputReal, outputImag});
-+
-+    return success();
-+  }
-+};
-+
-+struct TosaTransposeConv2DConvert final
-+    : public TosaOpConversionPattern<tosa::TransposeConv2DOp> {
-+  using TosaOpConversionPattern<
-+      tosa::TransposeConv2DOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::TransposeConv2DOp op,
-+                  tosa::TransposeConv2DOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+    DenseIntElementsAttr outPad = getI32TensorArmAttr(
-+        SmallVector<int32_t>(adaptor.getOutPad()), rewriter);
-+    DenseIntElementsAttr stride = getI32TensorArmAttr(
-+        SmallVector<int32_t>(adaptor.getStride()), rewriter);
-+    auto accType = convertAccType(adaptor.getAccType());
-+    auto localBound = adaptor.getLocalBound();
-+    Value input = adaptor.getInput();
-+    Value weight = adaptor.getWeight();
-+    Value bias = adaptor.getBias();
-+    Value inputZp = adaptor.getInputZp();
-+    Value weightZp = adaptor.getWeightZp();
-+    rewriter.replaceOpWithNewOp<spirv::TosaTransposeConv2DOp>(
-+        op, convertType(op.getType()), outPad, stride, accType, localBound,
-+        input, weight, bias, inputZp, weightZp);
-+    return success();
-+  }
-+};
-+
-+struct TosaClampConvert final : public TosaOpConversionPattern<tosa::ClampOp> {
-+  using TosaOpConversionPattern<tosa::ClampOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::ClampOp op, tosa::ClampOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+    auto minVal = adaptor.getMinVal();
-+    auto maxVal = adaptor.getMaxVal();
-+    auto nanMode =
-+        static_cast<spirv::TosaExtNaNPropagationModeType>(adaptor.getNanMode());
-+    Value input = adaptor.getInput();
-+    rewriter.replaceOpWithNewOp<spirv::TosaClampOp>(
-+        op, convertType(op.getType()), minVal, maxVal, nanMode, input);
-+    return success();
-+  }
-+};
-+
-+struct TosaErfConvert final : public TosaOpConversionPattern<tosa::ErfOp> {
-+  using TosaOpConversionPattern<tosa::ErfOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::ErfOp op, tosa::ErfOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input = adaptor.getInput();
-+    rewriter.replaceOpWithNewOp<spirv::TosaErfOp>(op, convertType(op.getType()),
-+                                                  input);
-+    return success();
-+  }
-+};
-+
-+struct TosaSigmoidConvert final
-+    : public TosaOpConversionPattern<tosa::SigmoidOp> {
-+  using TosaOpConversionPattern<tosa::SigmoidOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::SigmoidOp op, tosa::SigmoidOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input = adaptor.getInput();
-+    rewriter.replaceOpWithNewOp<spirv::TosaSigmoidOp>(
-+        op, convertType(op.getType()), input);
-+    return success();
-+  }
-+};
-+
-+struct TosaTanhConvert final : public TosaOpConversionPattern<tosa::TanhOp> {
-+  using TosaOpConversionPattern<tosa::TanhOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::TanhOp op, tosa::TanhOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input = adaptor.getInput();
-+    rewriter.replaceOpWithNewOp<spirv::TosaTanhOp>(
-+        op, convertType(op.getType()), input);
-+    return success();
-+  }
-+};
-+
-+struct TosaAddConvert final : public TosaOpConversionPattern<tosa::AddOp> {
-+  using TosaOpConversionPattern<tosa::AddOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::AddOp op, tosa::AddOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    Value input2 = adaptor.getInput2();
-+    rewriter.replaceOpWithNewOp<spirv::TosaAddOp>(op, convertType(op.getType()),
-+                                                  input1, input2);
-+    return success();
-+  }
-+};
-+
-+struct TosaArithmeticRightShiftConvert final
-+    : public TosaOpConversionPattern<tosa::ArithmeticRightShiftOp> {
-+  using TosaOpConversionPattern<
-+      tosa::ArithmeticRightShiftOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::ArithmeticRightShiftOp op,
-+                  tosa::ArithmeticRightShiftOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+    auto round = adaptor.getRound();
-+    Value input1 = adaptor.getInput1();
-+    Value input2 = adaptor.getInput2();
-+    rewriter.replaceOpWithNewOp<spirv::TosaArithmeticRightShiftOp>(
-+        op, convertType(op.getType()), round, input1, input2);
-+    return success();
-+  }
-+};
-+
-+struct TosaBitwiseAndConvert final
-+    : public TosaOpConversionPattern<tosa::BitwiseAndOp> {
-+  using TosaOpConversionPattern<tosa::BitwiseAndOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::BitwiseAndOp op, tosa::BitwiseAndOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    Value input2 = adaptor.getInput2();
-+    rewriter.replaceOpWithNewOp<spirv::TosaBitwiseAndOp>(
-+        op, convertType(op.getType()), input1, input2);
-+    return success();
-+  }
-+};
-+
-+struct TosaBitwiseOrConvert final
-+    : public TosaOpConversionPattern<tosa::BitwiseOrOp> {
-+  using TosaOpConversionPattern<tosa::BitwiseOrOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::BitwiseOrOp op, tosa::BitwiseOrOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    Value input2 = adaptor.getInput2();
-+    rewriter.replaceOpWithNewOp<spirv::TosaBitwiseOrOp>(
-+        op, convertType(op.getType()), input1, input2);
-+    return success();
-+  }
-+};
-+
-+struct TosaBitwiseXorConvert final
-+    : public TosaOpConversionPattern<tosa::BitwiseXorOp> {
-+  using TosaOpConversionPattern<tosa::BitwiseXorOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::BitwiseXorOp op, tosa::BitwiseXorOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    Value input2 = adaptor.getInput2();
-+    rewriter.replaceOpWithNewOp<spirv::TosaBitwiseXorOp>(
-+        op, convertType(op.getType()), input1, input2);
-+    return success();
-+  }
-+};
-+
-+struct TosaIntDivConvert final
-+    : public TosaOpConversionPattern<tosa::IntDivOp> {
-+  using TosaOpConversionPattern<tosa::IntDivOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::IntDivOp op, tosa::IntDivOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    Value input2 = adaptor.getInput2();
-+    rewriter.replaceOpWithNewOp<spirv::TosaIntDivOp>(
-+        op, convertType(op.getType()), input1, input2);
-+    return success();
-+  }
-+};
-+
-+struct TosaLogicalAndConvert final
-+    : public TosaOpConversionPattern<tosa::LogicalAndOp> {
-+  using TosaOpConversionPattern<tosa::LogicalAndOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::LogicalAndOp op, tosa::LogicalAndOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    Value input2 = adaptor.getInput2();
-+    rewriter.replaceOpWithNewOp<spirv::TosaLogicalAndOp>(
-+        op, convertType(op.getType()), input1, input2);
-+    return success();
-+  }
-+};
-+
-+struct TosaLogicalLeftShiftConvert final
-+    : public TosaOpConversionPattern<tosa::LogicalLeftShiftOp> {
-+  using TosaOpConversionPattern<
-+      tosa::LogicalLeftShiftOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::LogicalLeftShiftOp op,
-+                  tosa::LogicalLeftShiftOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    Value input2 = adaptor.getInput2();
-+    rewriter.replaceOpWithNewOp<spirv::TosaLogicalLeftShiftOp>(
-+        op, convertType(op.getType()), input1, input2);
-+    return success();
-+  }
-+};
-+
-+struct TosaLogicalRightShiftConvert final
-+    : public TosaOpConversionPattern<tosa::LogicalRightShiftOp> {
-+  using TosaOpConversionPattern<
-+      tosa::LogicalRightShiftOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::LogicalRightShiftOp op,
-+                  tosa::LogicalRightShiftOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    Value input2 = adaptor.getInput2();
-+    rewriter.replaceOpWithNewOp<spirv::TosaLogicalRightShiftOp>(
-+        op, convertType(op.getType()), input1, input2);
-+    return success();
-+  }
-+};
-+
-+struct TosaLogicalOrConvert final
-+    : public TosaOpConversionPattern<tosa::LogicalOrOp> {
-+  using TosaOpConversionPattern<tosa::LogicalOrOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::LogicalOrOp op, tosa::LogicalOrOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    Value input2 = adaptor.getInput2();
-+    rewriter.replaceOpWithNewOp<spirv::TosaLogicalOrOp>(
-+        op, convertType(op.getType()), input1, input2);
-+    return success();
-+  }
-+};
-+
-+struct TosaLogicalXorConvert final
-+    : public TosaOpConversionPattern<tosa::LogicalXorOp> {
-+  using TosaOpConversionPattern<tosa::LogicalXorOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::LogicalXorOp op, tosa::LogicalXorOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    Value input2 = adaptor.getInput2();
-+    rewriter.replaceOpWithNewOp<spirv::TosaLogicalXorOp>(
-+        op, convertType(op.getType()), input1, input2);
-+    return success();
-+  }
-+};
-+
-+struct TosaMaximumConvert final
-+    : public TosaOpConversionPattern<tosa::MaximumOp> {
-+  using TosaOpConversionPattern<tosa::MaximumOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::MaximumOp op, tosa::MaximumOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+    auto nanMode =
-+        static_cast<spirv::TosaExtNaNPropagationModeType>(adaptor.getNanMode());
-+    Value input1 = adaptor.getInput1();
-+    Value input2 = adaptor.getInput2();
-+    rewriter.replaceOpWithNewOp<spirv::TosaMaximumOp>(
-+        op, convertType(op.getType()), nanMode, input1, input2);
-+    return success();
-+  }
-+};
-+
-+struct TosaMinimumConvert final
-+    : public TosaOpConversionPattern<tosa::MinimumOp> {
-+  using TosaOpConversionPattern<tosa::MinimumOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::MinimumOp op, tosa::MinimumOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+    auto nanMode =
-+        static_cast<spirv::TosaExtNaNPropagationModeType>(adaptor.getNanMode());
-+    Value input1 = adaptor.getInput1();
-+    Value input2 = adaptor.getInput2();
-+    rewriter.replaceOpWithNewOp<spirv::TosaMinimumOp>(
-+        op, convertType(op.getType()), nanMode, input1, input2);
-+    return success();
-+  }
-+};
-+
-+struct TosaMulConvert final : public TosaOpConversionPattern<tosa::MulOp> {
-+  using TosaOpConversionPattern<tosa::MulOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::MulOp op, tosa::MulOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    Value input2 = adaptor.getInput2();
-+    Value shift = adaptor.getShift();
-+    rewriter.replaceOpWithNewOp<spirv::TosaMulOp>(op, convertType(op.getType()),
-+                                                  input1, input2, shift);
-+    return success();
-+  }
-+};
-+
-+struct TosaPowConvert final : public TosaOpConversionPattern<tosa::PowOp> {
-+  using TosaOpConversionPattern<tosa::PowOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::PowOp op, tosa::PowOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    Value input2 = adaptor.getInput2();
-+    rewriter.replaceOpWithNewOp<spirv::TosaPowOp>(op, convertType(op.getType()),
-+                                                  input1, input2);
-+    return success();
-+  }
-+};
-+
-+struct TosaSubConvert final : public TosaOpConversionPattern<tosa::SubOp> {
-+  using TosaOpConversionPattern<tosa::SubOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::SubOp op, tosa::SubOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    Value input2 = adaptor.getInput2();
-+    rewriter.replaceOpWithNewOp<spirv::TosaSubOp>(op, convertType(op.getType()),
-+                                                  input1, input2);
-+    return success();
-+  }
-+};
-+
-+struct TosaTableConvert final : public TosaOpConversionPattern<tosa::TableOp> {
-+  using TosaOpConversionPattern<tosa::TableOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::TableOp op, tosa::TableOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    Value table = adaptor.getTable();
-+    rewriter.replaceOpWithNewOp<spirv::TosaTableOp>(
-+        op, convertType(op.getType()), input1, table);
-+    return success();
-+  }
-+};
-+
-+struct TosaAbsConvert final : public TosaOpConversionPattern<tosa::AbsOp> {
-+  using TosaOpConversionPattern<tosa::AbsOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::AbsOp op, tosa::AbsOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    rewriter.replaceOpWithNewOp<spirv::TosaAbsOp>(op, convertType(op.getType()),
-+                                                  input1);
-+    return success();
-+  }
-+};
-+
-+struct TosaBitwiseNotConvert final
-+    : public TosaOpConversionPattern<tosa::BitwiseNotOp> {
-+  using TosaOpConversionPattern<tosa::BitwiseNotOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::BitwiseNotOp op, tosa::BitwiseNotOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    rewriter.replaceOpWithNewOp<spirv::TosaBitwiseNotOp>(
-+        op, convertType(op.getType()), input1);
-+    return success();
-+  }
-+};
-+
-+struct TosaCeilConvert final : public TosaOpConversionPattern<tosa::CeilOp> {
-+  using TosaOpConversionPattern<tosa::CeilOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::CeilOp op, tosa::CeilOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    rewriter.replaceOpWithNewOp<spirv::TosaCeilOp>(
-+        op, convertType(op.getType()), input1);
-+    return success();
-+  }
-+};
-+
-+struct TosaClzConvert final : public TosaOpConversionPattern<tosa::ClzOp> {
-+  using TosaOpConversionPattern<tosa::ClzOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::ClzOp op, tosa::ClzOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    rewriter.replaceOpWithNewOp<spirv::TosaClzOp>(op, convertType(op.getType()),
-+                                                  input1);
-+    return success();
-+  }
-+};
-+
-+struct TosaCosConvert final : public TosaOpConversionPattern<tosa::CosOp> {
-+  using TosaOpConversionPattern<tosa::CosOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::CosOp op, tosa::CosOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    rewriter.replaceOpWithNewOp<spirv::TosaCosOp>(op, convertType(op.getType()),
-+                                                  input1);
-+    return success();
-+  }
-+};
-+
-+struct TosaExpConvert final : public TosaOpConversionPattern<tosa::ExpOp> {
-+  using TosaOpConversionPattern<tosa::ExpOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::ExpOp op, tosa::ExpOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    rewriter.replaceOpWithNewOp<spirv::TosaExpOp>(op, convertType(op.getType()),
-+                                                  input1);
-+    return success();
-+  }
-+};
-+
-+struct TosaFloorConvert final : public TosaOpConversionPattern<tosa::FloorOp> {
-+  using TosaOpConversionPattern<tosa::FloorOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::FloorOp op, tosa::FloorOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    rewriter.replaceOpWithNewOp<spirv::TosaFloorOp>(
-+        op, convertType(op.getType()), input1);
-+    return success();
-+  }
-+};
-+
-+struct TosaLogConvert final : public TosaOpConversionPattern<tosa::LogOp> {
-+  using TosaOpConversionPattern<tosa::LogOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::LogOp op, tosa::LogOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    rewriter.replaceOpWithNewOp<spirv::TosaLogOp>(op, convertType(op.getType()),
-+                                                  input1);
-+    return success();
-+  }
-+};
-+
-+struct TosaLogicalNotConvert final
-+    : public TosaOpConversionPattern<tosa::LogicalNotOp> {
-+  using TosaOpConversionPattern<tosa::LogicalNotOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::LogicalNotOp op, tosa::LogicalNotOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    rewriter.replaceOpWithNewOp<spirv::TosaLogicalNotOp>(
-+        op, convertType(op.getType()), input1);
-+    return success();
-+  }
-+};
-+
-+struct TosaNegateConvert final
-+    : public TosaOpConversionPattern<tosa::NegateOp> {
-+  using TosaOpConversionPattern<tosa::NegateOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::NegateOp op, tosa::NegateOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    Value input1Zp = adaptor.getInput1Zp();
-+    Value outputZp = adaptor.getOutputZp();
-+    rewriter.replaceOpWithNewOp<spirv::TosaNegateOp>(
-+        op, convertType(op.getType()), input1, input1Zp, outputZp);
-+    return success();
-+  }
-+};
-+
-+struct TosaReciprocalConvert final
-+    : public TosaOpConversionPattern<tosa::ReciprocalOp> {
-+  using TosaOpConversionPattern<tosa::ReciprocalOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::ReciprocalOp op, tosa::ReciprocalOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    rewriter.replaceOpWithNewOp<spirv::TosaReciprocalOp>(
-+        op, convertType(op.getType()), input1);
-+    return success();
-+  }
-+};
-+
-+struct TosaRsqrtConvert final : public TosaOpConversionPattern<tosa::RsqrtOp> {
-+  using TosaOpConversionPattern<tosa::RsqrtOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::RsqrtOp op, tosa::RsqrtOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    rewriter.replaceOpWithNewOp<spirv::TosaRsqrtOp>(
-+        op, convertType(op.getType()), input1);
-+    return success();
-+  }
-+};
-+
-+struct TosaSinConvert final : public TosaOpConversionPattern<tosa::SinOp> {
-+  using TosaOpConversionPattern<tosa::SinOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::SinOp op, tosa::SinOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    rewriter.replaceOpWithNewOp<spirv::TosaSinOp>(op, convertType(op.getType()),
-+                                                  input1);
-+    return success();
-+  }
-+};
-+
-+struct TosaSelectConvert final
-+    : public TosaOpConversionPattern<tosa::SelectOp> {
-+  using TosaOpConversionPattern<tosa::SelectOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::SelectOp op, tosa::SelectOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    Value input2 = adaptor.getInput2();
-+    Value input3 = adaptor.getInput3();
-+    rewriter.replaceOpWithNewOp<spirv::TosaSelectOp>(
-+        op, convertType(op.getType()), input1, input2, input3);
-+    return success();
-+  }
-+};
-+
-+struct TosaEqualConvert final : public TosaOpConversionPattern<tosa::EqualOp> {
-+  using TosaOpConversionPattern<tosa::EqualOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::EqualOp op, tosa::EqualOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    Value input2 = adaptor.getInput2();
-+    rewriter.replaceOpWithNewOp<spirv::TosaEqualOp>(
-+        op, convertType(op.getType()), input1, input2);
-+    return success();
-+  }
-+};
-+
-+struct TosaGreaterConvert final
-+    : public TosaOpConversionPattern<tosa::GreaterOp> {
-+  using TosaOpConversionPattern<tosa::GreaterOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::GreaterOp op, tosa::GreaterOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    Value input2 = adaptor.getInput2();
-+    rewriter.replaceOpWithNewOp<spirv::TosaGreaterOp>(
-+        op, convertType(op.getType()), input1, input2);
-+    return success();
-+  }
-+};
-+
-+struct TosaGreaterEqualConvert final
-+    : public TosaOpConversionPattern<tosa::GreaterEqualOp> {
-+  using TosaOpConversionPattern<tosa::GreaterEqualOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::GreaterEqualOp op, tosa::GreaterEqualOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    Value input2 = adaptor.getInput2();
-+    rewriter.replaceOpWithNewOp<spirv::TosaGreaterEqualOp>(
-+        op, convertType(op.getType()), input1, input2);
-+    return success();
-+  }
-+};
-+
-+struct TosaReduceAllConvert final
-+    : public TosaOpConversionPattern<tosa::ReduceAllOp> {
-+  using TosaOpConversionPattern<tosa::ReduceAllOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::ReduceAllOp op, tosa::ReduceAllOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+    auto axis = adaptor.getAxis();
-+    Value input = adaptor.getInput();
-+    rewriter.replaceOpWithNewOp<spirv::TosaReduceAllOp>(
-+        op, convertType(op.getType()), axis, input);
-+    return success();
-+  }
-+};
-+
-+struct TosaReduceAnyConvert final
-+    : public TosaOpConversionPattern<tosa::ReduceAnyOp> {
-+  using TosaOpConversionPattern<tosa::ReduceAnyOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::ReduceAnyOp op, tosa::ReduceAnyOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+    auto axis = adaptor.getAxis();
-+    Value input = adaptor.getInput();
-+    rewriter.replaceOpWithNewOp<spirv::TosaReduceAnyOp>(
-+        op, convertType(op.getType()), axis, input);
-+    return success();
-+  }
-+};
-+
-+struct TosaReduceMaxConvert final
-+    : public TosaOpConversionPattern<tosa::ReduceMaxOp> {
-+  using TosaOpConversionPattern<tosa::ReduceMaxOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::ReduceMaxOp op, tosa::ReduceMaxOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+    auto axis = adaptor.getAxis();
-+    auto nanMode =
-+        static_cast<spirv::TosaExtNaNPropagationModeType>(adaptor.getNanMode());
-+    Value input = adaptor.getInput();
-+    rewriter.replaceOpWithNewOp<spirv::TosaReduceMaxOp>(
-+        op, convertType(op.getType()), axis, nanMode, input);
-+    return success();
-+  }
-+};
-+
-+struct TosaReduceMinConvert final
-+    : public TosaOpConversionPattern<tosa::ReduceMinOp> {
-+  using TosaOpConversionPattern<tosa::ReduceMinOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::ReduceMinOp op, tosa::ReduceMinOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+    auto axis = adaptor.getAxis();
-+    auto nanMode =
-+        static_cast<spirv::TosaExtNaNPropagationModeType>(adaptor.getNanMode());
-+    Value input = adaptor.getInput();
-+    rewriter.replaceOpWithNewOp<spirv::TosaReduceMinOp>(
-+        op, convertType(op.getType()), axis, nanMode, input);
-+    return success();
-+  }
-+};
-+
-+struct TosaReduceProductConvert final
-+    : public TosaOpConversionPattern<tosa::ReduceProductOp> {
-+  using TosaOpConversionPattern<tosa::ReduceProductOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::ReduceProductOp op,
-+                  tosa::ReduceProductOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+    auto axis = adaptor.getAxis();
-+    Value input = adaptor.getInput();
-+    rewriter.replaceOpWithNewOp<spirv::TosaReduceProductOp>(
-+        op, convertType(op.getType()), axis, input);
-+    return success();
-+  }
-+};
-+
-+struct TosaReduceSumConvert final
-+    : public TosaOpConversionPattern<tosa::ReduceSumOp> {
-+  using TosaOpConversionPattern<tosa::ReduceSumOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::ReduceSumOp op, tosa::ReduceSumOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+    auto axis = adaptor.getAxis();
-+    Value input = adaptor.getInput();
-+    rewriter.replaceOpWithNewOp<spirv::TosaReduceSumOp>(
-+        op, convertType(op.getType()), axis, input);
-+    return success();
-+  }
-+};
-+
-+struct TosaConcatConvert final
-+    : public TosaOpConversionPattern<tosa::ConcatOp> {
-+  using TosaOpConversionPattern<tosa::ConcatOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::ConcatOp op, tosa::ConcatOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+    auto axis = adaptor.getAxis();
-+    ValueRange input1 = adaptor.getInput1();
-+    if (input1.getTypes().size() > MAX_CONTACT_OP_INPUTS) {
-+      // The type is the same for all concat inputs so extract the first
-+      ShapedType inputType = dyn_cast<ShapedType>(input1.getTypes().front());
-+      if (!inputType) {
-+        return emitError(op->getLoc(),
-+                         "input types of Concat must be shaped types");
-+      }
-+      splitConcat(op, adaptor.getAxis(), axis, input1, inputType, rewriter);
-+    } else {
-+      rewriter.replaceOpWithNewOp<spirv::TosaConcatOp>(
-+          op, convertType(op.getType()), axis, input1);
-+    }
-+    return success();
-+  }
-+};
-+
-+struct TosaPadConvert final : public TosaOpConversionPattern<tosa::PadOp> {
-+  using TosaOpConversionPattern<tosa::PadOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::PadOp op, tosa::PadOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    Value padding = adaptor.getPadding();
-+    Value padConst = adaptor.getPadConst();
-+    rewriter.replaceOpWithNewOp<spirv::TosaPadOp>(op, convertType(op.getType()),
-+                                                  input1, padding, padConst);
-+    return success();
-+  }
-+};
-+
-+struct TosaReshapeConvert final
-+    : public TosaOpConversionPattern<tosa::ReshapeOp> {
-+  using TosaOpConversionPattern<tosa::ReshapeOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::ReshapeOp op, tosa::ReshapeOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    Value shape = adaptor.getShape();
-+    rewriter.replaceOpWithNewOp<spirv::TosaReshapeOp>(
-+        op, convertType(op.getType()), input1, shape);
-+    return success();
-+  }
-+};
-+
-+struct TosaReverseConvert final
-+    : public TosaOpConversionPattern<tosa::ReverseOp> {
-+  using TosaOpConversionPattern<tosa::ReverseOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::ReverseOp op, tosa::ReverseOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+    auto axis = adaptor.getAxis();
-+    Value input1 = adaptor.getInput1();
-+    rewriter.replaceOpWithNewOp<spirv::TosaReverseOp>(
-+        op, convertType(op.getType()), axis, input1);
-+    return success();
-+  }
-+};
-+
-+struct TosaSliceConvert final : public TosaOpConversionPattern<tosa::SliceOp> {
-+  using TosaOpConversionPattern<tosa::SliceOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::SliceOp op, tosa::SliceOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    Value start = adaptor.getStart();
-+    Value size = adaptor.getSize();
-+    rewriter.replaceOpWithNewOp<spirv::TosaSliceOp>(
-+        op, convertType(op.getType()), input1, start, size);
-+    return success();
-+  }
-+};
-+
-+struct TosaTileConvert final : public TosaOpConversionPattern<tosa::TileOp> {
-+  using TosaOpConversionPattern<tosa::TileOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::TileOp op, tosa::TileOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input1 = adaptor.getInput1();
-+    Value multiples = adaptor.getMultiples();
-+    rewriter.replaceOpWithNewOp<spirv::TosaTileOp>(
-+        op, convertType(op.getType()), input1, multiples);
-+    return success();
-+  }
-+};
-+
-+struct TosaTransposeConvert final
-+    : public TosaOpConversionPattern<tosa::TransposeOp> {
-+  using TosaOpConversionPattern<tosa::TransposeOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::TransposeOp op, tosa::TransposeOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+    DenseIntElementsAttr perms =
-+        getI32TensorArmAttr(SmallVector<int32_t>(adaptor.getPerms()), rewriter);
-+    Value input1 = adaptor.getInput1();
-+    rewriter.replaceOpWithNewOp<spirv::TosaTransposeOp>(
-+        op, convertType(op.getType()), perms, input1);
-+    return success();
-+  }
-+};
-+
-+struct TosaGatherConvert final
-+    : public TosaOpConversionPattern<tosa::GatherOp> {
-+  using TosaOpConversionPattern<tosa::GatherOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::GatherOp op, tosa::GatherOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value values = adaptor.getValues();
-+    Value indices = adaptor.getIndices();
-+    rewriter.replaceOpWithNewOp<spirv::TosaGatherOp>(
-+        op, convertType(op.getType()), values, indices);
-+    return success();
-+  }
-+};
-+
-+struct TosaScatterConvert final
-+    : public TosaOpConversionPattern<tosa::ScatterOp> {
-+  using TosaOpConversionPattern<tosa::ScatterOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::ScatterOp op, tosa::ScatterOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value valuesIn = adaptor.getValuesIn();
-+    Value indices = adaptor.getIndices();
-+    Value input = adaptor.getInput();
-+    rewriter.replaceOpWithNewOp<spirv::TosaScatterOp>(
-+        op, convertType(op.getType()), valuesIn, indices, input);
-+    return success();
-+  }
-+};
-+
-+struct TosaResizeConvert final
-+    : public TosaOpConversionPattern<tosa::ResizeOp> {
-+  using TosaOpConversionPattern<tosa::ResizeOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::ResizeOp op, tosa::ResizeOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+    auto mode = static_cast<spirv::TosaExtResizeModeType>(adaptor.getMode());
-+    Value input = adaptor.getInput();
-+    Value scale = adaptor.getScale();
-+    Value offset = adaptor.getOffset();
-+    Value border = adaptor.getBorder();
-+    rewriter.replaceOpWithNewOp<spirv::TosaResizeOp>(
-+        op, convertType(op.getType()), mode, input, scale, offset, border);
-+    return success();
-+  }
-+};
-+
-+struct TosaCastConvert final : public TosaOpConversionPattern<tosa::CastOp> {
-+  using TosaOpConversionPattern<tosa::CastOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::CastOp op, tosa::CastOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    Value input = adaptor.getInput();
-+    rewriter.replaceOpWithNewOp<spirv::TosaCastOp>(
-+        op, convertType(op.getType()), input);
-+    return success();
-+  }
-+};
-+
-+struct TosaRescaleConvert final
-+    : public TosaOpConversionPattern<tosa::RescaleOp> {
-+  using TosaOpConversionPattern<tosa::RescaleOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::RescaleOp op, tosa::RescaleOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+    auto scale32 = adaptor.getScale32();
-+    auto roundingMode =
-+        static_cast<spirv::TosaExtRoundingModeType>(adaptor.getRoundingMode());
-+    auto perChannel = adaptor.getPerChannel();
-+    auto inputUnsigned = adaptor.getInputUnsigned();
-+    auto outputUnsigned = adaptor.getOutputUnsigned();
-+    Value input = adaptor.getInput();
-+    Value multiplier = adaptor.getMultiplier();
-+    Value shift = adaptor.getShift();
-+    Value inputZp = adaptor.getInputZp();
-+    Value outputZp = adaptor.getOutputZp();
-+    rewriter.replaceOpWithNewOp<spirv::TosaRescaleOp>(
-+        op, convertType(op.getType()), scale32, roundingMode, perChannel,
-+        inputUnsigned, outputUnsigned, input, multiplier, shift, inputZp,
-+        outputZp);
-+    return success();
-+  }
-+};
-+
-+struct TosaConstConvert final : public TosaOpConversionPattern<tosa::ConstOp> {
-+  using TosaOpConversionPattern<tosa::ConstOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::ConstOp op, tosa::ConstOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    if (op->use_empty()) {
-+      rewriter.eraseOp(op);
-+      return success();
-+    }
-+
-+    auto graphConstId = getGraphIdForConst(op);
-+    if (graphConstId.has_value()) {
-+      rewriter.replaceOpWithNewOp<spirv::GraphConstantARMOp>(
-+          op, convertType(op.getType()), graphConstId.value());
-+      return success();
-+    }
-+
-+    ElementsAttr convertedValue;
-+    if (maybeConvertValue(op.getLoc(), adaptor.getValues(), convertedValue)
-+            .failed()) {
-+      return failure();
-+    }
-+    rewriter.replaceOpWithNewOp<spirv::ConstantOp>(
-+        op, convertType(op.getType()), convertedValue);
-+
-+    return success();
-+  }
-+};
-+
-+struct TosaIdentityConvert final
-+    : public TosaOpConversionPattern<tosa::IdentityOp> {
-+  using TosaOpConversionPattern<tosa::IdentityOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::IdentityOp op, tosa::IdentityOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    rewriter.replaceOp(op, adaptor.getInput1());
-+    return success();
-+  }
-+};
-+
-+struct TosaConstShapeConvert final
-+    : public TosaOpConversionPattern<tosa::ConstShapeOp> {
-+  using TosaOpConversionPattern<tosa::ConstShapeOp>::TosaOpConversionPattern;
-+
-+  LogicalResult
-+  matchAndRewrite(tosa::ConstShapeOp op, tosa::ConstShapeOpAdaptor adaptor,
-+                  ConversionPatternRewriter &rewriter) const override {
-+
-+    if (op->use_empty()) {
-+      rewriter.eraseOp(op);
-+      return success();
-+    }
-+
-+    auto graphConstId = getGraphIdForConst(op);
-+    if (graphConstId.has_value()) {
-+      rewriter.replaceOpWithNewOp<spirv::GraphConstantARMOp>(
-+          op, convertType(op.getType()), graphConstId.value());
-+      return success();
-+    }
-+
-+    ElementsAttr convertedValue;
-+    if (maybeConvertValue(op.getLoc(), adaptor.getValues(), convertedValue)
-+            .failed()) {
-+      return failure();
-+    }
-+    rewriter.replaceOpWithNewOp<spirv::ConstantOp>(
-+        op, convertType(op.getType()), convertedValue);
-+
-+    return success();
-+  }
-+};
-+
-+} // namespace
-+
-+void populateTosaToSPIRVTosaOpsConversionPatterns(
-+    SPIRVTypeConverter &typeConverter, RewritePatternSet &patterns) {
-+  patterns.add<
-+      TosaArgMaxConvert, TosaAvgPool2DConvert, TosaConv2DConvert,
-+      TosaConv3DConvert, TosaDepthwiseConv2DConvert, TosaFFT2DConvert,
-+      TosaMatMulConvert, TosaMaxPool2DConvert, TosaRFFT2DConvert,
-+      TosaTransposeConv2DConvert, TosaClampConvert, TosaErfConvert,
-+      TosaSigmoidConvert, TosaTanhConvert, TosaAddConvert,
-+      TosaArithmeticRightShiftConvert, TosaBitwiseAndConvert,
-+      TosaBitwiseOrConvert, TosaBitwiseXorConvert, TosaIntDivConvert,
-+      TosaLogicalAndConvert, TosaLogicalLeftShiftConvert,
-+      TosaLogicalRightShiftConvert, TosaLogicalOrConvert, TosaLogicalXorConvert,
-+      TosaMaximumConvert, TosaMinimumConvert, TosaMulConvert, TosaPowConvert,
-+      TosaSubConvert, TosaTableConvert, TosaAbsConvert, TosaBitwiseNotConvert,
-+      TosaCeilConvert, TosaClzConvert, TosaCosConvert, TosaExpConvert,
-+      TosaFloorConvert, TosaLogConvert, TosaLogicalNotConvert,
-+      TosaNegateConvert, TosaReciprocalConvert, TosaRsqrtConvert,
-+      TosaSinConvert, TosaSelectConvert, TosaEqualConvert, TosaGreaterConvert,
-+      TosaGreaterEqualConvert, TosaReduceAllConvert, TosaReduceAnyConvert,
-+      TosaReduceMaxConvert, TosaReduceMinConvert, TosaReduceProductConvert,
-+      TosaReduceSumConvert, TosaConcatConvert, TosaPadConvert,
-+      TosaReshapeConvert, TosaReverseConvert, TosaSliceConvert, TosaTileConvert,
-+      TosaTransposeConvert, TosaGatherConvert, TosaScatterConvert,
-+      TosaResizeConvert, TosaCastConvert, TosaRescaleConvert, TosaConstConvert,
-+      TosaIdentityConvert, TosaConstShapeConvert>(typeConverter,
-+                                                  patterns.getContext());
-+}
-+
-+} // namespace tosa
-+} // namespace mlir
+ 
+ spirv::VerCapExtAttr getDefaultVerCapExtAttr(MLIRContext *context);
+ 
 diff --git a/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosaPass.cpp b/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosaPass.cpp
-new file mode 100644
-index 000000000000..4d26f0301cee
---- /dev/null
+index abc1d5a4e2fc..b38c0b35e912 100644
+--- a/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosaPass.cpp
 +++ b/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosaPass.cpp
-@@ -0,0 +1,183 @@
-+//===- TosaToSPIRVTosaPass.cpp - Lower TOSA to SPIR-V Graph/TOSA ----------===//
-+//
-+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-+// See https://llvm.org/LICENSE.txt for license information.
-+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-+//
-+//===----------------------------------------------------------------------===//
-+//
-+// This pass lowers TOSA IR to the SPIR-V Graph/TOSA representation.
-+//
-+//===----------------------------------------------------------------------===//
-+
-+#include "mlir/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosa.h"
-+
-+#include "mlir/Dialect/Func/IR/FuncOps.h"
-+#include "mlir/Dialect/SPIRV/IR/SPIRVDialect.h"
-+#include "mlir/Dialect/SPIRV/Transforms/SPIRVConversion.h"
-+#include "mlir/Dialect/Tosa/IR/TosaOps.h"
-+#include "mlir/Dialect/Tosa/Transforms/Passes.h"
-+#include "mlir/IR/TypeUtilities.h"
-+#include "mlir/Pass/PassManager.h"
-+#include "mlir/Transforms/DialectConversion.h"
-+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-+
-+namespace mlir {
-+#define GEN_PASS_DEF_TOSATOSPIRVTOSA
-+#include "mlir/Conversion/Passes.h.inc"
-+} // namespace mlir
-+
-+namespace mlir {
-+namespace tosa {
-+namespace {
-+
-+spirv::VerCapExtAttr getVerCapExtAttr(MLIRContext *context) {
-+  return spirv::VerCapExtAttr::get(
-+      spirv::Version::V_1_5,
-+      {
-+          spirv::Capability::VulkanMemoryModel,
-+          spirv::Capability::Shader,
-+          spirv::Capability::Int8,
-+          spirv::Capability::Int16,
-+          spirv::Capability::Int64,
-+          spirv::Capability::Float16,
-+          spirv::Capability::BFloat16TypeKHR,
-+          spirv::Capability::Float8EXT,
-+          spirv::Capability::TensorsARM,
-+          spirv::Capability::GraphARM,
-+          spirv::Capability::ReplicatedCompositesEXT,
-+      },
-+      {
-+          spirv::Extension::SPV_ARM_tensors,
-+          spirv::Extension::SPV_ARM_graph,
-+          spirv::Extension::SPV_KHR_vulkan_memory_model,
-+          spirv::Extension::SPV_EXT_replicated_composites,
-+          spirv::Extension::SPV_KHR_bfloat16,
-+          spirv::Extension::SPV_EXT_float8,
-+          spirv::Extension::SPV_KHR_non_semantic_info,
-+      },
-+      context);
-+}
-+
-+struct TosaToSPIRVTosa : public impl::TosaToSPIRVTosaBase<TosaToSPIRVTosa> {
-+public:
+@@ -162,6 +162,7 @@ LogicalResult verifyGraphConstantIdAttrs(Operation *op) {
+ }
+ 
+ struct TosaToSPIRVTosa final : impl::TosaToSPIRVTosaBase<TosaToSPIRVTosa> {
 +  TosaToSPIRVTosa(bool analysis = false) : analysis(analysis) {}
-+
-+  void runOnOperation() override {
-+    MLIRContext *context = &getContext();
-+    RewritePatternSet patterns(context);
-+    Operation *op = getOperation();
-+
-+    auto targetAttr = spirv::lookupTargetEnv(op);
-+    if (!targetAttr) {
-+      targetAttr = spirv::TargetEnvAttr::get(
-+          getVerCapExtAttr(context), spirv::getDefaultResourceLimits(context),
-+          spirv::ClientAPI::Unknown, spirv::Vendor::Unknown,
-+          spirv::DeviceType::Unknown, spirv::TargetEnvAttr::kUnknownDeviceID);
-+    }
-+
-+    std::unique_ptr<ConversionTarget> target =
-+        SPIRVConversionTarget::get(targetAttr);
-+
-+    target->addLegalDialect<spirv::SPIRVDialect>();
-+    target->addIllegalDialect<tosa::TosaDialect>();
-+
-+    SPIRVTypeConverter typeConverter(targetAttr);
-+    typeConverter.addConversion([this](IntegerType integerType) {
-+      return this->convertIntegerType(integerType);
-+    });
-+    typeConverter.addConversion([this](TensorType tensorType) {
-+      return this->convertTensorType(tensorType);
-+    });
-+    typeConverter.addConversion([this](tosa::shapeType shapeType) {
-+      return this->convertShapeType(shapeType);
-+    });
-+
-+    populateTosaToSPIRVTosaConversionPatterns(typeConverter, patterns);
-+    populateTosaToSPIRVTosaOpsConversionPatterns(typeConverter, patterns);
-+
-+    auto targetEnvAttrName = spirv::getTargetEnvAttrName();
-+    auto symbolTableOp = SymbolTable::getNearestSymbolTable(op);
-+    if (symbolTableOp && !symbolTableOp->hasAttrOfType<spirv::TargetEnvAttr>(
-+                             targetEnvAttrName)) {
-+      symbolTableOp->setAttr(targetEnvAttrName, targetAttr);
-+    }
-+
-+    FrozenRewritePatternSet frozenPatterns(std::move(patterns));
-+
+ 
+   void runOnOperation() override {
+     MLIRContext *context = &getContext();
+@@ -213,12 +214,31 @@ struct TosaToSPIRVTosa final : impl::TosaToSPIRVTosaBase<TosaToSPIRVTosa> {
+ 
+     FrozenRewritePatternSet frozenPatterns(std::move(patterns));
+ 
 +    if (analysis) {
 +      DenseSet<Operation *> convertedOps;
 +      ConversionConfig config;
 +      config.legalizableOps = &convertedOps;
-+      if (failed(applyAnalysisConversion(op, *target, frozenPatterns, config)))
++      if (failed(
++              applyAnalysisConversion(op, *target, frozenPatterns, config))) {
 +        signalPassFailure();
++        return;
++      }
 +
-+      for (Operation *op : convertedOps) {
-+        if (llvm::isa<TosaDialect>(op->getDialect())) {
-+          llvm::errs() << "Successfully lowered: " << op->getName() << " at "
-+                       << op->getLoc() << "\n";
-+        }
++      for (Operation *convertedOp : convertedOps) {
++        if (isa<TosaDialect>(convertedOp->getDialect()))
++          llvm::errs() << "Successfully lowered: " << convertedOp->getName()
++                       << " at " << convertedOp->getLoc() << "\n";
 +      }
 +    }
 +
-+    if (failed(applyPartialConversion(op, *target, frozenPatterns))) {
-+      signalPassFailure();
-+    }
-+  }
-+
-+private:
+     if (failed(applyPartialConversion(op, *target, frozenPatterns))) {
+       signalPassFailure();
+     }
+   }
+ 
+ private:
 +  bool analysis;
 +
-+  IntegerType convertIntegerType(IntegerType integerType) {
-+    if (integerType.getWidth() == 48) {
-+      return IntegerType::get(&getContext(), 64, integerType.getSignedness());
-+    }
-+
-+    if (integerType.getWidth() == 4) {
-+      return IntegerType::get(&getContext(), 8, integerType.getSignedness());
-+    }
-+
-+    return integerType;
-+  }
-+
-+  SmallVector<int64_t> convertShape(ArrayRef<int64_t> shape) {
-+    bool requiresRankConversion =
-+        llvm::all_of(shape, [](int64_t dim) { return dim == 0; });
-+    if (requiresRankConversion)
-+      return SmallVector<int64_t>({1});
-+    bool isPartiallyDynamic =
-+        llvm::any_of(shape, [](int64_t dim) { return dim < 0; }) &&
-+        llvm::any_of(shape, [](int64_t dim) { return dim > 0; });
-+    if (isPartiallyDynamic)
-+      return SmallVector<int64_t>(shape.size(), ShapedType::kDynamic);
-+    return SmallVector<int64_t>(shape);
-+  }
-+
-+  spirv::TensorArmType convertTensorType(TensorType tensorType) {
-+    Type elementType = getElementTypeOrSelf(tensorType);
-+    if (elementType.isIndex())
-+      elementType = IntegerType::get(&getContext(), 32);
-+    if (auto integerType = dyn_cast<IntegerType>(elementType))
-+      elementType = convertIntegerType(integerType);
-+
-+    SmallVector<int64_t> shape = tensorType.hasRank()
-+                                     ? convertShape(tensorType.getShape())
-+                                     : SmallVector<int64_t>();
-+
-+    return spirv::TensorArmType::get(shape, elementType);
-+  }
-+
-+  spirv::TensorArmType convertShapeType(tosa::shapeType shapeType) {
-+    const auto rank = std::max(shapeType.getRank(), 1);
-+    return spirv::TensorArmType::get({rank},
-+                                     IntegerType::get(&getContext(), 32));
-+  }
-+};
-+} // namespace
-+
+   IntegerType convertIntegerType(IntegerType integerType) {
+     if (integerType.getWidth() == 48) {
+       return IntegerType::get(&getContext(), 64, integerType.getSignedness());
+@@ -277,8 +297,8 @@ private:
+ };
+ } // namespace
+ 
+-std::unique_ptr<Pass> createTosaToSPIRVTosa() {
+-  return std::make_unique<TosaToSPIRVTosa>();
 +std::unique_ptr<Pass> createTosaToSPIRVTosa(bool analysis) {
 +  return std::make_unique<TosaToSPIRVTosa>(analysis);
-+}
-+
-+} // namespace tosa
-+} // namespace mlir
+ }
+ 
+ } // namespace tosa

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -276,6 +276,8 @@ class Builder:
                     "-quiet",
                     f"-j{self.threads}",
                     f"-p{self.build_dir}",
+                    # The compile database may contain GCC-only warning flags.
+                    "-extra-arg=-Wno-unknown-warning-option",
                 ] + src_dirs
 
                 if self.clang_tidy_fix:

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -5,7 +5,6 @@
 
 #include "compiler.hpp"
 #include "include/passes.hpp"
-#include "mlir/Conversion/TosaToSPIRVTosa/ConvertTosaConstants.h"
 #include "mlir/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosa.h"
 #include "mlir/Dialect/SPIRV/IR/SPIRVDialect.h"
 #include "mlir/Dialect/SPIRV/Transforms/Passes.h"
@@ -112,7 +111,7 @@ void Compiler::SetPassManager() {
             // Run constant folding before assigning graph constant IDs so fold-created constants get stable,
             // sequence-wide IDs before partitioning clones them into graph segments.
             funcNestedPM.addPass(mlir::tosa::createTosaLayerwiseConstantFoldPass());
-            funcNestedPM.addPass(mlir::tosa::createConvertTosaConstantsPass());
+            funcNestedPM.addPass(mlir::tosa::createTosaToSPIRVTosaMarkGraphConstants());
         }
         _pm.addPass(createModelPartitionMarkingPass());
         _pm.addPass(createModelPartitioningPass({_options.analysis}));

--- a/src/conversion/model_partitioning.cpp
+++ b/src/conversion/model_partitioning.cpp
@@ -8,6 +8,7 @@
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "vgf-dialect/VGFDialect.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Base64.h"
 #include "llvm/Support/Error.h"
 
@@ -386,6 +387,29 @@ bool hasNonRematerializableExternalUse(Operation *op, int64_t partitionId) {
     return false;
 }
 
+bool isPartitionResult(Operation *op, ArrayRef<Value> results) {
+    return llvm::any_of(op->getResults(), [&](Value result) { return llvm::is_contained(results, result); });
+}
+bool hasUseInPartition(Operation *op, int64_t partitionId) {
+    for (Value result : op->getResults()) {
+        for (Operation *user : result.getUsers()) {
+            auto userPartitionAttr = user->getAttrOfType<IntegerAttr>("graph_partition_id");
+            if (userPartitionAttr && userPartitionAttr.getInt() == partitionId) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool shouldClonePartitionOp(Operation *op, int64_t partitionId, ArrayRef<Value> results) {
+    if (!isCompileTimeTosaConstant(op)) {
+        return true;
+    }
+
+    return isPartitionResult(op, results) || hasUseInPartition(op, partitionId);
+}
+
 struct PartitionDependencies {
     SmallVector<Value> inputs;
     SmallVector<Value> compileTimeConstantsToClone;
@@ -555,6 +579,10 @@ class ModelPartitioningPass : public impl::ModelPartitioningPassBase<ModelPartit
 
                             cloneCompileTimeConstants(builder, dependencies.compileTimeConstantsToClone, funcMapping);
                             for (Operation *op : partitionOps) {
+                                if (!shouldClonePartitionOp(op, partitionId, results)) {
+                                    op->setAttr("delete", BoolAttr::get(context, true));
+                                    continue;
+                                }
                                 builder.clone(*op, funcMapping);
                                 op->setAttr("delete", BoolAttr::get(context, true));
                             }

--- a/src/conversion/vgf_constants.cpp
+++ b/src/conversion/vgf_constants.cpp
@@ -4,7 +4,7 @@
  */
 
 #include "include/passes.hpp"
-#include "mlir/Conversion/TosaToSPIRVTosa/ConvertTosaConstants.h"
+#include "mlir/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosa.h"
 #include "mlir/Target/SPIRV/Serialization.h"
 #include "utils.hpp"
 #include "vgf_builder.hpp"
@@ -56,9 +56,9 @@ class VGFConstantsPass : public impl::VGFConstantsPassBase<VGFConstantsPass> {
         std::map<uint32_t, tosa::ConstOp> constantsById;
         moduleOp.walk([&constantsById](Operation *op) {
             if (auto constOp = llvm::dyn_cast<tosa::ConstOp>(op)) {
-                const auto id = tosa::getGraphIdForConst(constOp);
-                if (id.has_value()) {
-                    constantsById.try_emplace(id.value(), constOp);
+                auto id = constOp->getAttrOfType<IntegerAttr>(tosa::graphARMGraphConstantIdAttrName);
+                if (id != nullptr) {
+                    constantsById.try_emplace(static_cast<uint32_t>(id.getInt()), constOp);
                 }
             }
         });


### PR DESCRIPTION
Update the LLVM manifest revision to
bd209f39b43f958a1ac338c338a9a9538751b2fe and refresh llvm.patch as a single squashed commit on top of that base.

Adapt model-converter to the updated TosaToSPIRVTosa graph constant API, including the renamed graph constant marking pass and direct graph constant ID attribute lookup.

Avoid cloning unused rematerializable constants into graph partitions and delete the original top-level constants once rematerialized into the segments that use them.

Also link model-converter-opt with MLIRTosaTransforms for upstream TOSA pass registration used by lit tests.