### PR TITLE
Limit maybe-uninitialized suppression to GCC

### DIFF
--- a/cmake/toolchain/gcc.cmake
+++ b/cmake/toolchain/gcc.cmake
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright 2023-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2023-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
@@ -19,3 +19,5 @@ set(CMAKE_C_COMPILER "${GCC_PATH}" CACHE FILEPATH "C compiler")
 set(CMAKE_CXX_COMPILER "${GPP_PATH}" CACHE FILEPATH "C++ compiler")
 
 include(${CMAKE_CURRENT_LIST_DIR}/gnu_compiler_options.cmake)
+
+list(APPEND ML_SDK_MODEL_CONVERTER_COMPILE_OPTIONS -Wno-maybe-uninitialized)

--- a/cmake/toolchain/gnu_compiler_options.cmake
+++ b/cmake/toolchain/gnu_compiler_options.cmake
@@ -5,7 +5,3 @@
 
 # Compilation warnings
 set(ML_SDK_MODEL_CONVERTER_COMPILE_OPTIONS -Werror -Wall -Wextra -Wsign-conversion -Wconversion -Wpedantic)
-
-# GCC can report a false-positive maybe-uninitialized warning from generated
-# MLIR operation property hashing when compiling with optimizations.
-list(APPEND ML_SDK_MODEL_CONVERTER_COMPILE_OPTIONS -Wno-maybe-uninitialized)

--- a/cmake/toolchain/linux-aarch64-gcc.cmake
+++ b/cmake/toolchain/linux-aarch64-gcc.cmake
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright 2022-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2022-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
@@ -34,3 +34,5 @@ set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)    # Includes only in the target sys
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)    # Package files (e.g., pkg-config) in target sysroot
 
 include(${CMAKE_CURRENT_LIST_DIR}/gnu_compiler_options.cmake)
+
+list(APPEND ML_SDK_MODEL_CONVERTER_COMPILE_OPTIONS -Wno-maybe-uninitialized)


### PR DESCRIPTION
Move the GCC-only -Wno-maybe-uninitialized flag out of the shared GNU-style compiler options and into the GCC toolchain file.

Change-Id: Ifddae9933381e23cf5fe470ba543b041432a9822