### PR TITLE
 Fix partitioned multi-result output ordering for FFT/RFFT

### DIFF
--- a/src/conversion/model_partition_marking.cpp
+++ b/src/conversion/model_partition_marking.cpp
@@ -40,7 +40,7 @@ class ModelPartitionMarkingPass : public impl::ModelPartitionMarkingPassBase<Mod
                 for (auto [index, operand] : llvm::enumerate(op->getOperands())) {
                     if (Operation *input = operand.getDefiningOp()) {
                         input->setAttr("graph_partition_leaf_node", BoolAttr::get(op->getContext(), true));
-                        if (!op->getAttrOfType<IntegerAttr>("graph_partition_sequence_output_index")) {
+                        if (!input->getAttrOfType<IntegerAttr>("graph_partition_sequence_output_index")) {
                             input->setAttr("graph_partition_sequence_output_index",
                                            IntegerAttr::get(tI32, static_cast<int64_t>(index)));
                         }

--- a/src/conversion/model_partitioning.cpp
+++ b/src/conversion/model_partitioning.cpp
@@ -355,6 +355,14 @@ bool comparePartitionResultIndex(const Value &a, const Value &b) {
         bIdx = attr.getInt();
     }
 
+    if (aIdx == bIdx) {
+        auto aResult = llvm::dyn_cast<OpResult>(a);
+        auto bResult = llvm::dyn_cast<OpResult>(b);
+        if (aResult && bResult && a.getDefiningOp() == b.getDefiningOp()) {
+            return aResult.getResultNumber() < bResult.getResultNumber();
+        }
+    }
+
     return aIdx < bIdx;
 }
 

--- a/test/lit/model-partitioning-multi-result-order.mlir
+++ b/test/lit/model-partitioning-multi-result-order.mlir
@@ -1,0 +1,19 @@
+//
+// SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+
+// RUN: model-converter-opt --model-partition-marking --model-partitioning %s | FileCheck %s
+
+// CHECK-LABEL: vgf.sequence @main
+// CHECK: func.func @graph_partition_0() -> (tensor<1x32x32xf32>, tensor<1x32x32xf32>)
+// CHECK: %[[REAL:.*]], %[[IMAG:.*]] = tosa.fft2d
+// CHECK: return %[[REAL]], %[[IMAG]] : tensor<1x32x32xf32>, tensor<1x32x32xf32>
+// CHECK: %[[SEGMENT_EXEC:.*]]:2 = vgf.run_segment @graph_partition_0 () -> (tensor<1x32x32xf32>, tensor<1x32x32xf32>)
+// CHECK: vgf.sequence_output %[[SEGMENT_EXEC]]#0, %[[SEGMENT_EXEC]]#1 : tensor<1x32x32xf32>, tensor<1x32x32xf32>
+func.func @main() -> (tensor<1x32x32xf32> {tf_saved_model.index_path = ["output_0"]}, tensor<1x32x32xf32> {tf_saved_model.index_path = ["output_1"]}) attributes {tf.entry_function = {outputs = "output_0,output_1"}} {
+  %real = "tosa.const"() {values = dense<0.0> : tensor<1x32x32xf32>} : () -> tensor<1x32x32xf32>
+  %imag = "tosa.const"() {values = dense<0.0> : tensor<1x32x32xf32>} : () -> tensor<1x32x32xf32>
+  %output_real, %output_imag = tosa.fft2d %real, %imag {inverse = true} : (tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> (tensor<1x32x32xf32>, tensor<1x32x32xf32>)
+  return %output_real, %output_imag : tensor<1x32x32xf32>, tensor<1x32x32xf32>
+}


### PR DESCRIPTION
Change-Id: I42379d8c26c9e5789e70aaed85a4e3d2ce525299