### PR TITLE
Add custom op domain mapping CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,19 @@ To generate a TOSA flatbuffer file, run:
 ./build/model-converter --tosa-flatbuffer --input ${INPUT_TOSA} --output ${OUTPUT_TOSA_FB}
 ```
 
+To lower TOSA custom operations through the Arm.ExperimentalMLOperations CALL extended instruction, provide a domain to Opcode mapping:
+
+```bash
+./build/model-converter --input ${INPUT_TOSA} --output ${OUTPUT_VGF} \
+    --custom-op-domain-to-opcode com.example.accel:42
+```
+
+The `com.arm.bespoke` domain is reserved for Opcode 0 and must be enabled with `--enable-bespoke`:
+
+```bash
+./build/model-converter --input ${INPUT_TOSA} --output ${OUTPUT_VGF} --enable-bespoke
+```
+
 For more information, see the help output:
 
 ```bash

--- a/docs/help/model_converter_help.rst
+++ b/docs/help/model_converter_help.rst
@@ -1,14 +1,16 @@
-Usage: ./model-converter [--help] [--version] [--input VAR] [--output VAR] [--tosa-flatbuffer] [--tosa-flatbuffer-schema VAR] [--dump-mlir] [--emit-debug-info] [--require-static-shape] [--experimental-analysis] [--type-narrowing VAR]
+Usage: ./model-converter [--help] [--version] [--input VAR] [--output VAR] [--tosa-flatbuffer] [--tosa-flatbuffer-schema VAR] [--dump-mlir] [--emit-debug-info] [--require-static-shape] [--experimental-analysis] [--custom-op-domain-to-opcode VAR]... [--enable-bespoke] [--type-narrowing VAR]
 
 Optional arguments:
-  -h, --help                shows help message and exits
-  -v, --version             prints version information and exits
-  -i, --input               the input file to read TOSA FlatBuffer or TOSA MLIR data from [nargs=0..1] [default: "-"]
-  -o, --output              the output file to write VGF data to [nargs=0..1] [default: "-"]
-  --tosa-flatbuffer         write tosa FlatBuffer instead of VGF
-  --tosa-flatbuffer-schema  path to the tosa FlatBuffer schema [nargs=0..1] [default: ""]
-  --dump-mlir               Dump MLIR between each pass to std error
-  --emit-debug-info         Produce debug info instructions in SPIR-V assembly
-  --require-static-shape    Require all tensors to be ranked and have a specified shape. Terminate on deviation.
-  --experimental-analysis   Print analysis output (what operator lower and which errors out) for the input. [EXPERIMENTAL]
-  --type-narrowing          Perform type-narrowing to all operator operands/results from fp32 -> fp16 [nargs=0..1] [default: "none"]
+  -h, --help                    shows help message and exits
+  -v, --version                 prints version information and exits
+  -i, --input                   the input file to read TOSA FlatBuffer or TOSA MLIR data from [nargs=0..1] [default: "-"]
+  -o, --output                  the output file to write VGF data to [nargs=0..1] [default: "-"]
+  --tosa-flatbuffer             write tosa FlatBuffer instead of VGF
+  --tosa-flatbuffer-schema      path to the tosa FlatBuffer schema [nargs=0..1] [default: ""]
+  --dump-mlir                   Dump MLIR between each pass to std error
+  --emit-debug-info             Produce debug info instructions in SPIR-V assembly
+  --require-static-shape        Require all tensors to be ranked and have a specified shape. Terminate on deviation.
+  --experimental-analysis       Print analysis output (what operator lower and which errors out) for the input. [EXPERIMENTAL]
+  --custom-op-domain-to-opcode  Map TOSA custom op domains to Arm.ExperimentalMLOperations CALL Opcode literal integers. Entries use <domain>:<opcode> and can be specified multiple times. [nargs=0..1] [default: {}] [may be repeated]
+  --enable-bespoke              Enable com.arm.bespoke custom op lowering as an Arm.ExperimentalMLOperations CALL with Opcode 0.
+  --type-narrowing              Perform type-narrowing to all operator operands/results from fp32 -> fp16 [nargs=0..1] [default: "none"]

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -12,6 +12,7 @@
 #include "mlir/Transforms/Passes.h"
 #include "vgf-dialect/VGFDialect.h"
 #include "vgf_builder.hpp"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/ErrorHandling.h"
 
 #include "include/DeserializationPasses.h" // from @tosa_tools/mlir_translator
@@ -27,14 +28,33 @@ namespace mlsdk::model_converter {
 namespace {
 bool isTosaFlatbuffer(const std::string &input) { return std::filesystem::path(input).extension() == ".tosa"; }
 
+LogicalResult printPassOptionError(const Twine &message) {
+    llvm::errs() << message << "\n";
+    return failure();
+}
+
 std::unique_ptr<Pass> createConfiguredTosaSerializeJSONPass(const std::string &filename, const std::string &schema) {
     auto pass = mlir::tosa::createTosaSerializeJSONPass();
     std::string passOptions = "tosa-flatbuffer-filename=" + filename + " tosa-flatbuffer-schema=" + schema;
-    if (failed(pass->initializeOptions(passOptions, [](const Twine &message) {
-            llvm::errs() << message << "\n";
-            return failure();
-        }))) {
+    if (failed(pass->initializeOptions(passOptions, printPassOptionError))) {
         llvm::report_fatal_error("Failed to configure TOSA JSON serialization pass");
+    }
+    return pass;
+}
+std::unique_ptr<Pass> createConfiguredTosaToSPIRVTosaPass(bool analysis,
+                                                          const std::vector<std::string> &customOpDomainToOpcode) {
+    auto pass = mlir::tosa::createTosaToSPIRVTosa(analysis);
+    if (customOpDomainToOpcode.empty()) {
+        return pass;
+    }
+
+    std::string passOptions = "custom-op-domain-to-opcode=";
+    llvm::raw_string_ostream optionsStream(passOptions);
+    llvm::interleave(customOpDomainToOpcode, optionsStream, ",");
+    optionsStream.flush();
+
+    if (failed(pass->initializeOptions(passOptions, printPassOptionError))) {
+        llvm::report_fatal_error("Failed to configure TOSA to SPIR-V TOSA pass");
     }
     return pass;
 }
@@ -119,7 +139,7 @@ void Compiler::SetPassManager() {
         _pm.addPass(createCheckConstantSparsityPass());
         _pm.addPass(createVGFConstantsPass(builder));
         _pm.nest<vgf::SequenceOp>().addPass(createAssignGraphARMInterfaceVarABIPass());
-        _pm.addPass(mlir::tosa::createTosaToSPIRVTosa(_options.analysis));
+        _pm.addPass(createConfiguredTosaToSPIRVTosaPass(_options.analysis, _options.custom_op_domain_to_opcode));
 
         {
             // SPIRV Module Passes

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2022-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2022-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
@@ -13,6 +13,7 @@
 #include "llvm/Support/SourceMgr.h"
 
 #include <string>
+#include <vector>
 
 using namespace mlir;
 using namespace mlir::model_converter_passes;
@@ -31,8 +32,8 @@ class Compiler {
         bool emit_debug_info = false;
         bool require_static_shape = false;
         bool analysis = false;
-        // Optimizations
         TypeNarrowingMode type_narrowing = TypeNarrowingMode::None;
+        std::vector<std::string> custom_op_domain_to_opcode;
     };
 
     explicit Compiler(const Options &options);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,9 +1,11 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2023-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-FileCopyrightText: Copyright 2023-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 #include <argparse/argparse.hpp>
 #include <vgf/logging.hpp>
+
+#include "llvm/ADT/STLExtras.h"
 
 #include "compiler.hpp"
 #include "version.hpp"
@@ -13,6 +15,7 @@
 #include <cstring>
 #include <fstream>
 #include <sstream>
+#include <string_view>
 #include <vector>
 
 #ifdef _WIN32
@@ -25,6 +28,24 @@ using namespace mlsdk::model_converter;
 using namespace mlsdk::vgflib;
 
 namespace {
+
+constexpr std::string_view bespokeCustomOpDomain = "com.arm.bespoke";
+
+bool validateCustomOpDomainToOpcode(const std::vector<std::string> &mappings) {
+    auto reservedMapping = llvm::find_if(mappings, [](const std::string &mapping) {
+        const std::size_t delimiter = mapping.rfind(':');
+        return delimiter != std::string::npos &&
+               std::string_view(mapping).substr(0, delimiter) == bespokeCustomOpDomain;
+    });
+
+    if (reservedMapping == mappings.end()) {
+        return true;
+    }
+
+    llvm::errs() << "Bad custom op domain mapping: " << bespokeCustomOpDomain << " is reserved. "
+                 << "Use --enable-bespoke instead of --custom-op-domain-to-opcode " << *reservedMapping << "\n";
+    return false;
+}
 
 std::unique_ptr<argparse::ArgumentParser> createParser(int argc, const char *argv[]) {
     std::unique_ptr<argparse::ArgumentParser> parser = nullptr;
@@ -58,6 +79,15 @@ std::unique_ptr<argparse::ArgumentParser> createParser(int argc, const char *arg
             .implicit_value(true);
         parser->add_argument("--experimental-analysis")
             .help("Print analysis output (what operator lower and which errors out) for the input. [EXPERIMENTAL]")
+            .default_value(false)
+            .implicit_value(true);
+        parser->add_argument("--custom-op-domain-to-opcode")
+            .help("Map TOSA custom op domains to Arm.ExperimentalMLOperations CALL Opcode literal integers. Entries "
+                  "use <domain>:<opcode> and can be specified multiple times.")
+            .append()
+            .default_value(std::vector<std::string>{});
+        parser->add_argument("--enable-bespoke")
+            .help("Enable com.arm.bespoke custom op lowering as an Arm.ExperimentalMLOperations CALL with Opcode 0.")
             .default_value(false)
             .implicit_value(true);
         // Optimisation Options
@@ -117,6 +147,13 @@ int main(int argc, const char *argv[]) {
         options.emit_debug_info = parser->get<bool>("--emit-debug-info");
         options.require_static_shape = parser->get<bool>("--require-static-shape");
         options.analysis = parser->get<bool>("--experimental-analysis");
+        options.custom_op_domain_to_opcode = parser->get<std::vector<std::string>>("--custom-op-domain-to-opcode");
+        if (!validateCustomOpDomainToOpcode(options.custom_op_domain_to_opcode)) {
+            return -1;
+        }
+        if (parser->get<bool>("--enable-bespoke")) {
+            options.custom_op_domain_to_opcode.push_back(std::string(bespokeCustomOpDomain) + ":0");
+        }
         const std::string typeNarrowing = parser->get("--type-narrowing");
         if (typeNarrowing == "full") {
             options.type_narrowing = TypeNarrowingMode::Full;


### PR DESCRIPTION
Expose the patched TosaToSPIRVTosa custom op domain mapping through model-converter.

Add a repeatable --custom-op-domain-to-opcode option using the same <domain>:<opcode> structure as the MLIR pass option, and forward the collected mappings when constructing the TosaToSPIRVTosa pass.

Add --enable-bespoke as the supported way to enable the fixed com.arm.bespoke mapping to Arm.ExperimentalMLOperations CALL Opcode 0. Reject com.arm.bespoke when provided through the generic mapping option so the reserved domain cannot be remapped accidentally.