### PR TITLE
Fix GraphARM interface ABI attr spelling

### DIFF
--- a/src/conversion/assign_grapharm_interface_var_abi.cpp
+++ b/src/conversion/assign_grapharm_interface_var_abi.cpp
@@ -5,6 +5,7 @@
 
 #include "include/passes.hpp"
 
+#include "mlir/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosa.h"
 #include "llvm/ADT/STLExtras.h"
 
 namespace mlir::model_converter_passes {
@@ -12,7 +13,6 @@ namespace mlir::model_converter_passes {
 #include "passes.hpp.inc"
 namespace {
 
-constexpr StringLiteral graphARMInterfaceVarABIAttrName = "spv.grapharm.interface_var_abi";
 constexpr uint32_t graphARMDescriptorSet = 0;
 
 class AssignGraphARMInterfaceVarABIPass
@@ -132,12 +132,12 @@ class AssignGraphARMInterfaceVarABIPass
             }
 
             for (auto [argIndex, operand] : llvm::enumerate(runSegmentOp->getOperands())) {
-                funcOp.setArgAttr(static_cast<unsigned>(argIndex), graphARMInterfaceVarABIAttrName,
+                funcOp.setArgAttr(static_cast<unsigned>(argIndex), tosa::graphARMInterfaceVarABIAttrName,
                                   getInterfaceVarABIAttr(getBindingId(bindingIds, operand)));
             }
 
             for (auto [resultIndex, result] : llvm::enumerate(runSegmentOp->getResults())) {
-                funcOp.setResultAttr(static_cast<unsigned>(resultIndex), graphARMInterfaceVarABIAttrName,
+                funcOp.setResultAttr(static_cast<unsigned>(resultIndex), tosa::graphARMInterfaceVarABIAttrName,
                                      getInterfaceVarABIAttr(getBindingId(bindingIds, result)));
             }
 

--- a/src/include/passes.hpp
+++ b/src/include/passes.hpp
@@ -7,6 +7,7 @@
 
 #include "include/type_narrowing.hpp"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVDialect.h"
 #include "mlir/Dialect/SPIRV/IR/SPIRVOps.h"
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
 #include "mlir/Pass/Pass.h"

--- a/src/include/passes.td
+++ b/src/include/passes.td
@@ -26,8 +26,12 @@ def AssignGraphARMInterfaceVarABIPass : Pass<"assign-grapharm-interface-var-abi"
   let description = [{
     Computes the sequence-wide binding numbering currently used by VGF serialization
     and annotates graph segment func.func arguments/results with
-    spv.grapharm.interface_var_abi so tosa-to-spirv can preserve the final ABI.
+    grapharm.interface_var_abi so tosa-to-spirv can preserve the final ABI.
   }];
+  let dependentDialects = [
+    "func::FuncDialect",
+    "spirv::SPIRVDialect"
+  ];
 }
 
 def TosaShapedVerificationPass : Pass<"tosa-shape-verif", "func::FuncOp"> {

--- a/test/lit/assign-grapharm-interface-var-abi.mlir
+++ b/test/lit/assign-grapharm-interface-var-abi.mlir
@@ -1,0 +1,44 @@
+//
+// SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+
+// RUN: model-converter-opt --assign-grapharm-interface-var-abi %s | FileCheck %s
+
+vgf.sequence @main(%arg0: tensor<1xi8>) -> tensor<1xi8> {
+  vgf.segment @single_partition_0(%arg1: tensor<1xi8>) -> tensor<1xi8> attributes {segment_type = 0 : i32} {
+    // CHECK-LABEL: func.func @single_partition_0
+    // CHECK-SAME: grapharm.interface_var_abi = #spirv.interface_var_abi<(0, 0)>
+    // CHECK-SAME: grapharm.interface_var_abi = #spirv.interface_var_abi<(0, 1)>
+    func.func @single_partition_0(%arg2: tensor<1xi8>) -> tensor<1xi8> {
+      return %arg2 : tensor<1xi8>
+    }
+    vgf.segment_output
+  }
+  %0 = vgf.run_segment @single_partition_0 :(%arg0) (tensor<1xi8>) -> tensor<1xi8>
+  vgf.sequence_output %0 : tensor<1xi8>
+}
+
+vgf.sequence @multi_segment(%arg0: tensor<1xi8>) -> tensor<1xi8> {
+  vgf.segment @multi_partition_0(%arg1: tensor<1xi8>) -> tensor<1xi8> attributes {segment_type = 0 : i32} {
+    // CHECK-LABEL: func.func @multi_partition_0
+    // CHECK-SAME: grapharm.interface_var_abi = #spirv.interface_var_abi<(0, 0)>
+    // CHECK-SAME: grapharm.interface_var_abi = #spirv.interface_var_abi<(0, 1)>
+    func.func @multi_partition_0(%arg2: tensor<1xi8>) -> tensor<1xi8> {
+      return %arg2 : tensor<1xi8>
+    }
+    vgf.segment_output
+  }
+  %0 = vgf.run_segment @multi_partition_0 :(%arg0) (tensor<1xi8>) -> tensor<1xi8>
+  vgf.segment @multi_partition_1(%arg1: tensor<1xi8>) -> tensor<1xi8> attributes {segment_type = 0 : i32} {
+    // CHECK-LABEL: func.func @multi_partition_1
+    // CHECK-SAME: grapharm.interface_var_abi = #spirv.interface_var_abi<(0, 1)>
+    // CHECK-SAME: grapharm.interface_var_abi = #spirv.interface_var_abi<(0, 2)>
+    func.func @multi_partition_1(%arg2: tensor<1xi8>) -> tensor<1xi8> {
+      return %arg2 : tensor<1xi8>
+    }
+    vgf.segment_output
+  }
+  %1 = vgf.run_segment @multi_partition_1 :(%0) (tensor<1xi8>) -> tensor<1xi8>
+  vgf.sequence_output %1 : tensor<1xi8>
+}


### PR DESCRIPTION
Use the TosaToSPIRVTosa GraphARM ABI attribute name instead of a local stale spelling, and add lit coverage for single- and multi-segment VGF sequences.