### PR TITLE
Fix and normalize dependency version reporting

### DIFF
--- a/cmake/tosa-tools.cmake
+++ b/cmake/tosa-tools.cmake
@@ -6,7 +6,7 @@
 set(TOSA_TOOLS_PATH "TOSA_TOOLS-NOTFOUND" CACHE PATH "Path to TOSA Tools")
 set(tosa_serialize_VERSION "unknown")
 
-if(EXISTS ${ML_SDK_VGF_LIB_PATH}/CMakeLists.txt)
+if(EXISTS ${TOSA_TOOLS_PATH}/CMakeLists.txt)
     mlsdk_get_git_revision(${TOSA_TOOLS_PATH} tosa_serialize_VERSION)
     if(NOT TARGET tosa_serialize)
         set(BUILD_TESTS OFF CACHE BOOL "" FORCE)

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2024, 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
@@ -18,8 +18,14 @@ function(mlsdk_get_git_revision SRCDIR RETURN_GIT_REVISION)
         return()
     endif()
 
+    # Refresh cached stat metadata before describe so clean checkouts do not
+    # get a false -dirty suffix. Real local changes still report as dirty.
     execute_process(
-        COMMAND ${GIT_EXECUTABLE} describe --dirty --always --tag --broken
+        COMMAND ${GIT_EXECUTABLE} update-index -q --refresh
+        WORKING_DIRECTORY ${SRCDIR})
+
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} describe --dirty --always --tag --broken --long
         WORKING_DIRECTORY ${SRCDIR}
         RESULT_VARIABLE GIT_RETURN_CODE
         OUTPUT_VARIABLE GIT_OUTPUT
@@ -57,7 +63,7 @@ function(mlsdk_generate_version_header)
         set(depVersionVar "${dep}_VERSION")
         set(depVersion "unknown")
 
-        if(${depVersionVar})
+        if(DEFINED ${depVersionVar})
             set(depVersion "${${depVersionVar}}")
         else()
             message(WARNING "Unable to get version for ${dep}: ${depVersionVar} is not set")


### PR DESCRIPTION
Use the TOSA tools path when deciding whether to build TOSA tools from source, instead of checking the VGF lib path.

Refresh Git index metadata before running `git describe --dirty` so clean dependency checkouts do not get false dirty suffixes, while real local changes still report as dirty.

Use `git describe --long` to make exact tag versions consistently include the commit suffix, including lightweight tags.