### PR TITLE
Fix stack use in partition plan collection

### DIFF
--- a/src/conversion/model_partitioning.cpp
+++ b/src/conversion/model_partitioning.cpp
@@ -790,8 +790,8 @@ void FunctionPartitionEmitter::emit(const FunctionPartitionPlan &plan) {
     markForDeletion(plan.oldTerminator);
 }
 
-SmallVector<PlannedFunctionPartition, 8> collectFunctionPartitionPlans(ModuleOp moduleOp) {
-    SmallVector<PlannedFunctionPartition, 8> plannedFunctions;
+std::vector<PlannedFunctionPartition> collectFunctionPartitionPlans(ModuleOp moduleOp) {
+    std::vector<PlannedFunctionPartition> plannedFunctions;
     for (func::FuncOp funcOp : moduleOp.getOps<func::FuncOp>()) {
         PlannedFunctionPartition plannedFunction;
         plannedFunction.funcOp = funcOp;
@@ -813,7 +813,7 @@ void emitFunctionPartitionPlans(ArrayRef<PlannedFunctionPartition> plannedFuncti
 }
 
 void partitionModuleFunctions(ModuleOp moduleOp, MLIRContext *context) {
-    SmallVector<PlannedFunctionPartition, 8> plannedFunctions = collectFunctionPartitionPlans(moduleOp);
+    std::vector<PlannedFunctionPartition> plannedFunctions = collectFunctionPartitionPlans(moduleOp);
     emitFunctionPartitionPlans(plannedFunctions, context);
 }
 


### PR DESCRIPTION
SmallVector used to collect planned function partitions reserves too much inline storage on the stack. Each PlannedFunctionPartition contains nested planning state, so an inline capacity of 8 creates a large stack allocation for the outer collection.

Use std::vector for this module-level collection instead. The caller only needs contiguous storage that can be passed as an ArrayRef, and heap allocation avoids the large inline buffer without changing the partition planning behavior.