### PR TITLE
chore: refactor shared model partition helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,7 @@ set(CONVERTER_PASS_LIB_SOURCES
     "src/conversion/check_sparsity.cpp"
     "src/conversion/assign_grapharm_interface_var_abi.cpp"
     "src/conversion/dense_resource_inliner.cpp"
+    "src/conversion/model_partition_common.cpp"
     "src/conversion/model_partition_marking.cpp"
     "src/conversion/model_partitioning.cpp"
     "src/conversion/resource_planner.cpp"

--- a/src/conversion/model_partition_common.cpp
+++ b/src/conversion/model_partition_common.cpp
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+#include "model_partition_common.hpp"
+
+#include "include/custom_op_domains.hpp"
+
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"
+
+namespace mlir::model_converter_passes {
+
+bool isCompileTimeTosaConstant(Operation *op) { return llvm::isa_and_nonnull<tosa::ConstOp, tosa::ConstShapeOp>(op); }
+
+bool isVulkanCustomShaderOperation(Operation *op) {
+    auto customOp = llvm::dyn_cast_or_null<tosa::CustomOp>(op);
+    return customOp && isVulkanCustomShaderOp(customOp);
+}
+
+} // namespace mlir::model_converter_passes

--- a/src/conversion/model_partition_common.hpp
+++ b/src/conversion/model_partition_common.hpp
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+#pragma once
+
+namespace mlir {
+class Operation;
+} // namespace mlir
+
+namespace mlir::model_converter_passes {
+
+bool isCompileTimeTosaConstant(Operation *op);
+bool isVulkanCustomShaderOperation(Operation *op);
+
+} // namespace mlir::model_converter_passes

--- a/src/conversion/model_partition_marking.cpp
+++ b/src/conversion/model_partition_marking.cpp
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
-#include "include/custom_op_domains.hpp"
 #include "include/passes.hpp"
 #include "model_partition_attrs.hpp"
+#include "model_partition_common.hpp"
 
 #include <algorithm>
 #include <optional>
@@ -16,13 +16,6 @@ namespace mlir::model_converter_passes {
 namespace {
 
 enum class PartitionKind { Graph, Compute };
-
-bool isCompileTimeTosaConstant(Operation *op) { return llvm::isa_and_nonnull<tosa::ConstOp, tosa::ConstShapeOp>(op); }
-
-bool isVulkanCustomShaderOperation(Operation *op) {
-    auto customOp = llvm::dyn_cast_or_null<tosa::CustomOp>(op);
-    return customOp && isVulkanCustomShaderOp(customOp);
-}
 
 int64_t assignGraphPartitionAfterCompute(const int64_t candidatePartitionId, const int64_t highestPartitionId,
                                          const PartitionKind highestPartitionKind) {

--- a/src/conversion/model_partitioning.cpp
+++ b/src/conversion/model_partitioning.cpp
@@ -8,6 +8,7 @@
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "model_partition_attrs.hpp"
+#include "model_partition_common.hpp"
 #include "vgf-dialect/VGFDialect.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Base64.h"
@@ -370,13 +371,6 @@ bool comparePartitionResultIndex(const Value &a, const Value &b) {
     }
 
     return false;
-}
-
-bool isCompileTimeTosaConstant(Operation *op) { return llvm::isa_and_nonnull<tosa::ConstOp, tosa::ConstShapeOp>(op); }
-
-bool isVulkanCustomShaderOperation(Operation *op) {
-    auto customOp = llvm::dyn_cast_or_null<tosa::CustomOp>(op);
-    return customOp && isVulkanCustomShaderOp(customOp);
 }
 
 struct PartitionDependencies {


### PR DESCRIPTION
Move common model partition helper predicates into a shared source file so the marking and partitioning passes do not duplicate basic op classification logic.

This keeps compile-time TOSA constant detection and Vulkan custom shader detection in one place ahead of further partitioning changes.

Change-Id: Ic6c08b146f4031b7e7ee2c8ab9ef55c8ecd44ab5