### PR TITLE
feat: Narrow integer partition boundaries

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,12 @@
 
 ## Unreleased
 
+### Converter & Toolchain
+
+- Updated graph partitioning to keep eligible boundary rescale resources in
+  narrower integer formats by rematerializing widening rescale operations inside
+  graph partitions.
+
 ### Build, Packaging & Developer Experience
  - Updated Model Converter `--version` output to report the package version and include git revision and dependency revision information
 

--- a/src/conversion/model_partition_common.cpp
+++ b/src/conversion/model_partition_common.cpp
@@ -10,12 +10,56 @@
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
 
 namespace mlir::model_converter_passes {
+namespace {
+
+std::optional<unsigned> getIntegerElementBitWidth(Value value) {
+    auto type = llvm::dyn_cast<ShapedType>(value.getType());
+    if (!type || !type.getElementType().isInteger()) {
+        return std::nullopt;
+    }
+    return type.getElementType().getIntOrFloatBitWidth();
+}
+
+std::optional<DeferredMaterializationInfo> getRescaleDeferredMaterializationInfo(tosa::RescaleOp rescaleOp) {
+    const auto inputWidth = getIntegerElementBitWidth(rescaleOp.getInput());
+    const auto outputWidth = getIntegerElementBitWidth(rescaleOp->getResult(0));
+    if (!inputWidth || !outputWidth || *inputWidth >= *outputWidth) {
+        return std::nullopt;
+    }
+
+    DeferredMaterializationInfo info;
+    Value input = rescaleOp.getInput();
+    if (isCompileTimeTosaConstant(input.getDefiningOp())) {
+        info.constantsToClone.push_back(input);
+    } else {
+        info.runtimeInputs.push_back(input);
+    }
+
+    for (Value operand : rescaleOp->getOperands().drop_front()) {
+        if (!isCompileTimeTosaConstant(operand.getDefiningOp())) {
+            return std::nullopt;
+        }
+        info.constantsToClone.push_back(operand);
+    }
+
+    return info;
+}
+
+} // namespace
 
 bool isCompileTimeTosaConstant(Operation *op) { return llvm::isa_and_nonnull<tosa::ConstOp, tosa::ConstShapeOp>(op); }
 
 bool isVulkanCustomShaderOperation(Operation *op) {
     auto customOp = llvm::dyn_cast_or_null<tosa::CustomOp>(op);
     return customOp && isVulkanCustomShaderOp(customOp);
+}
+
+std::optional<DeferredMaterializationInfo> getDeferredMaterializationInfo(Operation *op) {
+    if (auto rescaleOp = llvm::dyn_cast_or_null<tosa::RescaleOp>(op)) {
+        return getRescaleDeferredMaterializationInfo(rescaleOp);
+    }
+
+    return std::nullopt;
 }
 
 } // namespace mlir::model_converter_passes

--- a/src/conversion/model_partition_common.hpp
+++ b/src/conversion/model_partition_common.hpp
@@ -5,13 +5,24 @@
 
 #pragma once
 
+#include "mlir/IR/Value.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <optional>
+
 namespace mlir {
 class Operation;
 } // namespace mlir
 
 namespace mlir::model_converter_passes {
 
+struct DeferredMaterializationInfo {
+    SmallVector<Value> runtimeInputs;
+    SmallVector<Value> constantsToClone;
+};
+
 bool isCompileTimeTosaConstant(Operation *op);
 bool isVulkanCustomShaderOperation(Operation *op);
+std::optional<DeferredMaterializationInfo> getDeferredMaterializationInfo(Operation *op);
 
 } // namespace mlir::model_converter_passes

--- a/src/conversion/model_partition_marking.cpp
+++ b/src/conversion/model_partition_marking.cpp
@@ -165,7 +165,9 @@ class PartitionPlan {
                         continue;
                     }
 
-                    if (!isRematerializableGraphUse(op, user)) {
+                    if (isRematerializableGraphUse(op, user)) {
+                        markRematerializedGraphInput(op);
+                    } else {
                         leafOps.insert(op);
                     }
                 }
@@ -242,14 +244,35 @@ class PartitionPlan {
         return *llvm::min_element(userPartitionIds);
     }
 
-    bool isRematerializableGraphUse(Operation *op, Operation *user) const {
-        if (!isCompileTimeTosaConstant(op) || llvm::isa<func::ReturnOp>(user) || isVulkanCustomShaderOperation(user)) {
+    bool isPlannedGraphPartitionUse(Operation *user) const {
+        if (llvm::isa<func::ReturnOp>(user) || isVulkanCustomShaderOperation(user)) {
             return false;
         }
 
         auto userPartitionIt = partitionByOp.find(user);
         return userPartitionIt != partitionByOp.end() &&
                partitionKinds.lookup(userPartitionIt->second) == PartitionKind::Graph;
+    }
+
+    bool isRematerializableGraphUse(Operation *op, Operation *user) const {
+        if (!isPlannedGraphPartitionUse(user)) {
+            return false;
+        }
+
+        return isCompileTimeTosaConstant(op) || getDeferredMaterializationInfo(op).has_value();
+    }
+
+    void markRematerializedGraphInput(Operation *op) {
+        std::optional<DeferredMaterializationInfo> info = getDeferredMaterializationInfo(op);
+        if (!info) {
+            return;
+        }
+
+        for (Value input : info->runtimeInputs) {
+            if (Operation *inputDefOp = input.getDefiningOp()) {
+                leafOps.insert(inputDefOp);
+            }
+        }
     }
 
     std::optional<int64_t> getLastPartitionOfKind(PartitionKind kind) const {

--- a/src/conversion/model_partitioning.cpp
+++ b/src/conversion/model_partitioning.cpp
@@ -373,9 +373,46 @@ bool comparePartitionResultIndex(const Value &a, const Value &b) {
     return false;
 }
 
+bool isMarkedGraphPartitionUse(Operation *user) {
+    if (llvm::isa<func::ReturnOp>(user) || isVulkanCustomShaderOperation(user)) {
+        return false;
+    }
+
+    auto partitionAttr = user->getAttrOfType<IntegerAttr>(graphPartitionIdAttrName);
+    return partitionAttr != nullptr;
+}
+
+bool isCrossPartitionGraphUse(Operation *user, int64_t partitionId) {
+    if (!isMarkedGraphPartitionUse(user)) {
+        return false;
+    }
+
+    auto userPartitionAttr = user->getAttrOfType<IntegerAttr>(graphPartitionIdAttrName);
+    return userPartitionAttr.getInt() != partitionId;
+}
+
+bool hasRematerializedGraphUse(Operation *op, int64_t partitionId) {
+    if (!getDeferredMaterializationInfo(op)) {
+        return false;
+    }
+
+    return llvm::any_of(op->getUsers(),
+                        [partitionId](Operation *user) { return isCrossPartitionGraphUse(user, partitionId); });
+}
+
+bool isOnlyNeededByRematerializedGraphUses(Operation *op, int64_t partitionId) {
+    if (!getDeferredMaterializationInfo(op) || op->use_empty()) {
+        return false;
+    }
+
+    return llvm::all_of(op->getUsers(),
+                        [partitionId](Operation *user) { return isCrossPartitionGraphUse(user, partitionId); });
+}
+
 struct PartitionDependencies {
     SmallVector<Value> inputs;
     SmallVector<Value> compileTimeConstantsToClone;
+    SmallVector<Value> rematerializedGraphValues;
 };
 
 struct PartitionState {
@@ -484,6 +521,7 @@ class FunctionPartitionEmitter {
     Operation *cloneWithoutPartitioningAttrs(Operation *op, IRMapping &mapping);
     Operation *clonePartitionOp(Operation *op, IRMapping &mapping);
     void cloneCompileTimeConstants(const SmallVector<Value> &constantsToClone, IRMapping &mapping);
+    void cloneRematerializedGraphOps(const SmallVector<Value> &values, IRMapping &mapping);
     template <typename ArgumentsT>
     static void mapValuesToArguments(ArrayRef<Value> values, ArgumentsT arguments, IRMapping &mapping);
     static SmallVector<Value> lookupMappedValues(ArrayRef<Value> values, IRMapping &mapping);
@@ -532,6 +570,11 @@ bool FunctionPartitionPlanner::hasExternalPartitionUse(Value value, int64_t part
         }
 
         auto userPartitionAttr = user->getAttrOfType<IntegerAttr>(graphPartitionIdAttrName);
+        if (userPartitionAttr && userPartitionAttr.getInt() == partitionId &&
+            hasRematerializedGraphUse(user, partitionId)) {
+            return true;
+        }
+
         if (userPartitionAttr && userPartitionAttr.getInt() != partitionId) {
             return true;
         }
@@ -554,11 +597,25 @@ bool FunctionPartitionPlanner::hasRuntimeUseOfCompileTimeConstant(Operation *op)
 }
 
 PartitionDependencies FunctionPartitionPlanner::collectPartitionDependencies(ArrayRef<Operation *> ops,
-                                                                             bool rematerializeCompileTimeConstants) {
+                                                                             bool rematerializeGraphDependencies) {
     DenseSet<Operation *> knownOps(ops.begin(), ops.end());
     DenseSet<Value> seenRuntimeInputs;
     DenseSet<Value> seenConstantsToClone;
+    DenseSet<Value> seenRematerializedValues;
     PartitionDependencies dependencies;
+
+    auto addRuntimeInput = [&](Value value) {
+        if (seenRuntimeInputs.insert(value).second) {
+            dependencies.inputs.push_back(value);
+        }
+    };
+
+    auto addCompileTimeConstantToClone = [&](Value value) {
+        if (seenConstantsToClone.insert(value).second) {
+            dependencies.compileTimeConstantsToClone.push_back(value);
+        }
+    };
+
     for (Operation *op : ops) {
         for (auto operand : op->getOperands()) {
             Operation *defOp = operand.getDefiningOp();
@@ -566,16 +623,31 @@ PartitionDependencies FunctionPartitionPlanner::collectPartitionDependencies(Arr
                 continue;
             }
 
-            if (rematerializeCompileTimeConstants && isCompileTimeTosaConstant(defOp)) {
-                if (seenConstantsToClone.insert(operand).second) {
-                    dependencies.compileTimeConstantsToClone.push_back(operand);
+            if (rematerializeGraphDependencies && isCompileTimeTosaConstant(defOp)) {
+                addCompileTimeConstantToClone(operand);
+                continue;
+            }
+
+            if (rematerializeGraphDependencies) {
+                std::optional<DeferredMaterializationInfo> info = getDeferredMaterializationInfo(defOp);
+                if (!info) {
+                    addRuntimeInput(operand);
+                    continue;
+                }
+
+                if (seenRematerializedValues.insert(operand).second) {
+                    dependencies.rematerializedGraphValues.push_back(operand);
+                    for (Value input : info->runtimeInputs) {
+                        addRuntimeInput(input);
+                    }
+                    for (Value constant : info->constantsToClone) {
+                        addCompileTimeConstantToClone(constant);
+                    }
                 }
                 continue;
             }
 
-            if (seenRuntimeInputs.insert(operand).second) {
-                dependencies.inputs.push_back(operand);
-            }
+            addRuntimeInput(operand);
         }
     }
 
@@ -669,9 +741,34 @@ Operation *FunctionPartitionEmitter::clonePartitionOp(Operation *op, IRMapping &
 void FunctionPartitionEmitter::cloneCompileTimeConstants(const SmallVector<Value> &constantsToClone,
                                                          IRMapping &mapping) {
     for (Value operand : constantsToClone) {
+        if (mapping.lookupOrDefault(operand) != operand) {
+            continue;
+        }
         Operation *defOp = operand.getDefiningOp();
         Operation *clonedConst = cloneWithoutPartitioningAttrs(defOp, mapping);
         mapping.map(operand, clonedConst->getResult(0));
+    }
+}
+
+void FunctionPartitionEmitter::cloneRematerializedGraphOps(const SmallVector<Value> &values, IRMapping &mapping) {
+    DenseSet<Operation *> clonedOps;
+    for (Value value : values) {
+        Operation *defOp = value.getDefiningOp();
+        if (!defOp || !clonedOps.insert(defOp).second) {
+            continue;
+        }
+
+        for (Value operand : defOp->getOperands()) {
+            if (mapping.lookupOrDefault(operand) != operand) {
+                continue;
+            }
+            Operation *operandDefOp = operand.getDefiningOp();
+            if (isCompileTimeTosaConstant(operandDefOp)) {
+                Operation *clonedConst = cloneWithoutPartitioningAttrs(operandDefOp, mapping);
+                mapping.map(operand, clonedConst->getResult(0));
+            }
+        }
+        cloneWithoutPartitioningAttrs(defOp, mapping);
     }
 }
 
@@ -744,7 +841,12 @@ void FunctionPartitionEmitter::createGraphSegmentBody(CreatedSegment &segment, c
         mapValuesToArguments(plan.dependencies.inputs, newFuncOp.getArguments(), funcMapping);
 
         cloneCompileTimeConstants(plan.dependencies.compileTimeConstantsToClone, funcMapping);
+        cloneRematerializedGraphOps(plan.dependencies.rematerializedGraphValues, funcMapping);
         for (Operation *op : plan.ops) {
+            if (isOnlyNeededByRematerializedGraphUses(op, plan.partitionId)) {
+                markForDeletion(op);
+                continue;
+            }
             clonePartitionOp(op, funcMapping);
         }
 

--- a/test/lit/model-partitioning-rematerialize-rescale.mlir
+++ b/test/lit/model-partitioning-rematerialize-rescale.mlir
@@ -1,0 +1,158 @@
+//
+// SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+
+// RUN: model-converter-opt --split-input-file --model-partition-marking --model-partitioning %s | FileCheck %s
+
+func.func @rescale_rematerialized_after_shader(%arg0: tensor<4xi8> {tf_saved_model.index_path = ["input_0"]}) -> (tensor<4xi32> {tf_saved_model.index_path = ["output_0"]}) attributes {tf.entry_function = {inputs = "input_0", outputs = "output_0"}} {
+  // CHECK-LABEL: vgf.sequence @rescale_rematerialized_after_shader
+  // CHECK: func.func @graph_partition_0(%{{[^:]+}}: tensor<4xi8>) -> tensor<4xi8>
+  // CHECK: return
+  // CHECK: vgf.segment @graph_partition_1
+  // CHECK: func.func @graph_partition_2(%{{[^:]+}}: tensor<4xi8>, %{{[^:]+}}: tensor<4xi8>) -> tensor<4xi32>
+  // CHECK: tosa.rescale
+  // CHECK: tosa.rescale
+  // CHECK: tosa.add
+  %multiplier = "tosa.const"() {values = dense<[1]> : tensor<1xi32>} : () -> tensor<1xi32>
+  %shift = "tosa.const"() {values = dense<[0]> : tensor<1xi8>} : () -> tensor<1xi8>
+  %input_zp = "tosa.const"() {values = dense<[0]> : tensor<1xi8>} : () -> tensor<1xi8>
+  %flow_output_zp = "tosa.const"() {values = dense<[0]> : tensor<1xi8>} : () -> tensor<1xi8>
+  %output_zp = "tosa.const"() {values = dense<[0]> : tensor<1xi32>} : () -> tensor<1xi32>
+  %flow = tosa.rescale %arg0, %multiplier, %shift, %input_zp, %flow_output_zp {rounding_mode = SINGLE_ROUND, per_channel = false, scale32 = true, input_unsigned = false, output_unsigned = false} : (tensor<4xi8>, tensor<1xi32>, tensor<1xi8>, tensor<1xi8>, tensor<1xi8>) -> tensor<4xi8>
+  %old_flow_i32 = tosa.rescale %flow, %multiplier, %shift, %input_zp, %output_zp {rounding_mode = SINGLE_ROUND, per_channel = false, scale32 = true, input_unsigned = false, output_unsigned = false} : (tensor<4xi8>, tensor<1xi32>, tensor<1xi8>, tensor<1xi8>, tensor<1xi32>) -> tensor<4xi32>
+  %shader = tosa.custom %flow {domain_name = "com.arm.VulkanCustomShader", implementation_attrs = "{\22entry_point\22:\22main\22,\22is_vkshader\22:true,\22workgroup_sizes\22:[1,1,1],\22input_0_binding\22:0,\22input_0_descriptorset\22:0,\22input_0_type\22:\22TENSOR\22,\22input_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22input_0_vkformat\22:\22VK_FORMAT_R8_SINT\22,\22output_0_binding\22:1,\22output_0_descriptorset\22:0,\22output_0_type\22:\22TENSOR\22,\22output_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22output_0_vkformat\22:\22VK_FORMAT_R8_SINT\22}", operator_name = "rescale_remat_shader"} : (tensor<4xi8>) -> tensor<4xi8>
+  %shader_i32 = tosa.rescale %shader, %multiplier, %shift, %input_zp, %output_zp {rounding_mode = SINGLE_ROUND, per_channel = false, scale32 = true, input_unsigned = false, output_unsigned = false} : (tensor<4xi8>, tensor<1xi32>, tensor<1xi8>, tensor<1xi8>, tensor<1xi32>) -> tensor<4xi32>
+  %out = tosa.add %shader_i32, %old_flow_i32 : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi32>
+  return %out : tensor<4xi32>
+}
+
+// -----
+
+func.func @rescale_compute_use_preserved_graph_use_rematerialized(%arg0: tensor<4xi8> {tf_saved_model.index_path = ["input_0"]}) -> (tensor<4xi32> {tf_saved_model.index_path = ["output_0"]}) attributes {tf.entry_function = {inputs = "input_0", outputs = "output_0"}} {
+  // CHECK-LABEL: vgf.sequence @rescale_compute_use_preserved_graph_use_rematerialized
+  // CHECK: func.func @graph_partition_0(%{{[^:]+}}: tensor<4xi8>) -> (tensor<4xi8>, tensor<4xi32>)
+  // CHECK: tosa.rescale
+  // CHECK: vgf.segment @graph_partition_1
+  // CHECK: vgf.run_segment @graph_partition_1 : (%{{[^)]*}}) (tensor<4xi32>) -> tensor<4xi32>
+  // CHECK: func.func @graph_partition_2(%{{[^:]+}}: tensor<4xi32>, %{{[^:]+}}: tensor<4xi8>) -> tensor<4xi32>
+  // CHECK: tosa.rescale
+  // CHECK: tosa.add
+  %multiplier = "tosa.const"() {values = dense<[1]> : tensor<1xi32>} : () -> tensor<1xi32>
+  %shift = "tosa.const"() {values = dense<[0]> : tensor<1xi8>} : () -> tensor<1xi8>
+  %input_zp = "tosa.const"() {values = dense<[0]> : tensor<1xi8>} : () -> tensor<1xi8>
+  %flow_output_zp = "tosa.const"() {values = dense<[0]> : tensor<1xi8>} : () -> tensor<1xi8>
+  %output_zp = "tosa.const"() {values = dense<[0]> : tensor<1xi32>} : () -> tensor<1xi32>
+  %flow = tosa.rescale %arg0, %multiplier, %shift, %input_zp, %flow_output_zp {rounding_mode = SINGLE_ROUND, per_channel = false, scale32 = true, input_unsigned = false, output_unsigned = false} : (tensor<4xi8>, tensor<1xi32>, tensor<1xi8>, tensor<1xi8>, tensor<1xi8>) -> tensor<4xi8>
+  %old_flow_i32 = tosa.rescale %flow, %multiplier, %shift, %input_zp, %output_zp {rounding_mode = SINGLE_ROUND, per_channel = false, scale32 = true, input_unsigned = false, output_unsigned = false} : (tensor<4xi8>, tensor<1xi32>, tensor<1xi8>, tensor<1xi8>, tensor<1xi32>) -> tensor<4xi32>
+  %shader = tosa.custom %old_flow_i32 {domain_name = "com.arm.VulkanCustomShader", implementation_attrs = "{\22entry_point\22:\22main\22,\22is_vkshader\22:true,\22workgroup_sizes\22:[1,1,1],\22input_0_binding\22:0,\22input_0_descriptorset\22:0,\22input_0_type\22:\22TENSOR\22,\22input_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22input_0_vkformat\22:\22VK_FORMAT_R32_SINT\22,\22output_0_binding\22:1,\22output_0_descriptorset\22:0,\22output_0_type\22:\22TENSOR\22,\22output_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22output_0_vkformat\22:\22VK_FORMAT_R32_SINT\22}", operator_name = "rescale_i32_shader"} : (tensor<4xi32>) -> tensor<4xi32>
+  %out = tosa.add %shader, %old_flow_i32 : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi32>
+  return %out : tensor<4xi32>
+}
+
+// -----
+
+func.func @rescale_model_output_preserved(%arg0: tensor<4xi8> {tf_saved_model.index_path = ["input_0"]}) -> (tensor<4xi32> {tf_saved_model.index_path = ["output_0"]}, tensor<4xi32> {tf_saved_model.index_path = ["output_1"]}) attributes {tf.entry_function = {inputs = "input_0", outputs = "output_0,output_1"}} {
+  // CHECK-LABEL: vgf.sequence @rescale_model_output_preserved
+  // CHECK: func.func @graph_partition_0(%{{[^:]+}}: tensor<4xi8>) -> (tensor<4xi32>, tensor<4xi8>)
+  // CHECK: func.func @graph_partition_2(%{{[^:]+}}: tensor<4xi8>, %{{[^:]+}}: tensor<4xi8>) -> tensor<4xi32>
+  // CHECK: vgf.sequence_output %{{.*}}, %{{.*}} : tensor<4xi32>, tensor<4xi32>
+  %multiplier = "tosa.const"() {values = dense<[1]> : tensor<1xi32>} : () -> tensor<1xi32>
+  %shift = "tosa.const"() {values = dense<[0]> : tensor<1xi8>} : () -> tensor<1xi8>
+  %input_zp = "tosa.const"() {values = dense<[0]> : tensor<1xi8>} : () -> tensor<1xi8>
+  %flow_output_zp = "tosa.const"() {values = dense<[0]> : tensor<1xi8>} : () -> tensor<1xi8>
+  %output_zp = "tosa.const"() {values = dense<[0]> : tensor<1xi32>} : () -> tensor<1xi32>
+  %flow = tosa.rescale %arg0, %multiplier, %shift, %input_zp, %flow_output_zp {rounding_mode = SINGLE_ROUND, per_channel = false, scale32 = true, input_unsigned = false, output_unsigned = false} : (tensor<4xi8>, tensor<1xi32>, tensor<1xi8>, tensor<1xi8>, tensor<1xi8>) -> tensor<4xi8>
+  %old_flow_i32 = tosa.rescale %flow, %multiplier, %shift, %input_zp, %output_zp {rounding_mode = SINGLE_ROUND, per_channel = false, scale32 = true, input_unsigned = false, output_unsigned = false} : (tensor<4xi8>, tensor<1xi32>, tensor<1xi8>, tensor<1xi8>, tensor<1xi32>) -> tensor<4xi32>
+  %shader = tosa.custom %flow {domain_name = "com.arm.VulkanCustomShader", implementation_attrs = "{\22entry_point\22:\22main\22,\22is_vkshader\22:true,\22workgroup_sizes\22:[1,1,1],\22input_0_binding\22:0,\22input_0_descriptorset\22:0,\22input_0_type\22:\22TENSOR\22,\22input_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22input_0_vkformat\22:\22VK_FORMAT_R8_SINT\22,\22output_0_binding\22:1,\22output_0_descriptorset\22:0,\22output_0_type\22:\22TENSOR\22,\22output_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22output_0_vkformat\22:\22VK_FORMAT_R8_SINT\22}", operator_name = "rescale_output_shader"} : (tensor<4xi8>) -> tensor<4xi8>
+  %shader_i32 = tosa.rescale %shader, %multiplier, %shift, %input_zp, %output_zp {rounding_mode = SINGLE_ROUND, per_channel = false, scale32 = true, input_unsigned = false, output_unsigned = false} : (tensor<4xi8>, tensor<1xi32>, tensor<1xi8>, tensor<1xi8>, tensor<1xi32>) -> tensor<4xi32>
+  %out = tosa.add %shader_i32, %old_flow_i32 : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi32>
+  return %out, %old_flow_i32 : tensor<4xi32>, tensor<4xi32>
+}
+
+// -----
+
+func.func @non_constant_rescale_params_not_rematerialized(%arg0: tensor<4xi8> {tf_saved_model.index_path = ["input_0"]}, %arg1: tensor<1xi32> {tf_saved_model.index_path = ["input_1"]}) -> (tensor<4xi32> {tf_saved_model.index_path = ["output_0"]}) attributes {tf.entry_function = {inputs = "input_0,input_1", outputs = "output_0"}} {
+  // CHECK-LABEL: vgf.sequence @non_constant_rescale_params_not_rematerialized
+  // CHECK: func.func @graph_partition_0(%{{[^:]+}}: tensor<4xi8>, %{{[^:]+}}: tensor<1xi32>) -> (tensor<4xi8>, tensor<4xi32>)
+  // CHECK: func.func @graph_partition_2(%{{[^:]+}}: tensor<4xi8>, %{{[^:]+}}: tensor<1xi32>, %{{[^:]+}}: tensor<4xi32>) -> tensor<4xi32>
+  %shift = "tosa.const"() {values = dense<[0]> : tensor<1xi8>} : () -> tensor<1xi8>
+  %input_zp = "tosa.const"() {values = dense<[0]> : tensor<1xi8>} : () -> tensor<1xi8>
+  %flow_output_zp = "tosa.const"() {values = dense<[0]> : tensor<1xi8>} : () -> tensor<1xi8>
+  %output_zp = "tosa.const"() {values = dense<[0]> : tensor<1xi32>} : () -> tensor<1xi32>
+  %flow = tosa.rescale %arg0, %arg1, %shift, %input_zp, %flow_output_zp {rounding_mode = SINGLE_ROUND, per_channel = false, scale32 = true, input_unsigned = false, output_unsigned = false} : (tensor<4xi8>, tensor<1xi32>, tensor<1xi8>, tensor<1xi8>, tensor<1xi8>) -> tensor<4xi8>
+  %old_flow_i32 = tosa.rescale %flow, %arg1, %shift, %input_zp, %output_zp {rounding_mode = SINGLE_ROUND, per_channel = false, scale32 = true, input_unsigned = false, output_unsigned = false} : (tensor<4xi8>, tensor<1xi32>, tensor<1xi8>, tensor<1xi8>, tensor<1xi32>) -> tensor<4xi32>
+  %shader = tosa.custom %flow {domain_name = "com.arm.VulkanCustomShader", implementation_attrs = "{\22entry_point\22:\22main\22,\22is_vkshader\22:true,\22workgroup_sizes\22:[1,1,1],\22input_0_binding\22:0,\22input_0_descriptorset\22:0,\22input_0_type\22:\22TENSOR\22,\22input_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22input_0_vkformat\22:\22VK_FORMAT_R8_SINT\22,\22output_0_binding\22:1,\22output_0_descriptorset\22:0,\22output_0_type\22:\22TENSOR\22,\22output_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22output_0_vkformat\22:\22VK_FORMAT_R8_SINT\22}", operator_name = "non_constant_rescale_params_shader"} : (tensor<4xi8>) -> tensor<4xi8>
+  %shader_i32 = tosa.rescale %shader, %arg1, %shift, %input_zp, %output_zp {rounding_mode = SINGLE_ROUND, per_channel = false, scale32 = true, input_unsigned = false, output_unsigned = false} : (tensor<4xi8>, tensor<1xi32>, tensor<1xi8>, tensor<1xi8>, tensor<1xi32>) -> tensor<4xi32>
+  %out = tosa.add %shader_i32, %old_flow_i32 : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi32>
+  return %out : tensor<4xi32>
+}
+
+// -----
+
+func.func @rescale_rematerialized_in_each_consuming_graph_partition(%arg0: tensor<4xi8> {tf_saved_model.index_path = ["input_0"]}) -> (tensor<4xi32> {tf_saved_model.index_path = ["output_0"]}) attributes {tf.entry_function = {inputs = "input_0", outputs = "output_0"}} {
+  // CHECK-LABEL: vgf.sequence @rescale_rematerialized_in_each_consuming_graph_partition
+  // CHECK: func.func @graph_partition_0(%{{[^:]+}}: tensor<4xi8>) -> tensor<4xi8>
+  // CHECK: tosa.reverse
+  // CHECK-NEXT: return
+  // CHECK: vgf.segment @graph_partition_1
+  // CHECK: func.func @graph_partition_2
+  // CHECK: tosa.rescale
+  // CHECK: tosa.rescale
+  // CHECK: tosa.add
+  // CHECK: vgf.segment @graph_partition_3
+  // CHECK: func.func @graph_partition_4
+  // CHECK: tosa.rescale
+  // CHECK: tosa.add
+  %multiplier = "tosa.const"() {values = dense<[1]> : tensor<1xi32>} : () -> tensor<1xi32>
+  %shift = "tosa.const"() {values = dense<[0]> : tensor<1xi8>} : () -> tensor<1xi8>
+  %input_zp = "tosa.const"() {values = dense<[0]> : tensor<1xi8>} : () -> tensor<1xi8>
+  %output_zp = "tosa.const"() {values = dense<[0]> : tensor<1xi32>} : () -> tensor<1xi32>
+  %flow = tosa.reverse %arg0 {axis = 0 : i32} : (tensor<4xi8>) -> tensor<4xi8>
+  %flow_i32 = tosa.rescale %flow, %multiplier, %shift, %input_zp, %output_zp {rounding_mode = SINGLE_ROUND, per_channel = false, scale32 = true, input_unsigned = false, output_unsigned = false} : (tensor<4xi8>, tensor<1xi32>, tensor<1xi8>, tensor<1xi8>, tensor<1xi32>) -> tensor<4xi32>
+  %shader_0 = tosa.custom %flow {domain_name = "com.arm.VulkanCustomShader", implementation_attrs = "{\22entry_point\22:\22main\22,\22is_vkshader\22:true,\22workgroup_sizes\22:[1,1,1],\22input_0_binding\22:0,\22input_0_descriptorset\22:0,\22input_0_type\22:\22TENSOR\22,\22input_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22input_0_vkformat\22:\22VK_FORMAT_R8_SINT\22,\22output_0_binding\22:1,\22output_0_descriptorset\22:0,\22output_0_type\22:\22TENSOR\22,\22output_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22output_0_vkformat\22:\22VK_FORMAT_R8_SINT\22}", operator_name = "first_shader"} : (tensor<4xi8>) -> tensor<4xi8>
+  %shader_0_i32 = tosa.rescale %shader_0, %multiplier, %shift, %input_zp, %output_zp {rounding_mode = SINGLE_ROUND, per_channel = false, scale32 = true, input_unsigned = false, output_unsigned = false} : (tensor<4xi8>, tensor<1xi32>, tensor<1xi8>, tensor<1xi8>, tensor<1xi32>) -> tensor<4xi32>
+  %graph_2 = tosa.add %shader_0_i32, %flow_i32 : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi32>
+  %shader_1 = tosa.custom %graph_2 {domain_name = "com.arm.VulkanCustomShader", implementation_attrs = "{\22entry_point\22:\22main\22,\22is_vkshader\22:true,\22workgroup_sizes\22:[1,1,1],\22input_0_binding\22:0,\22input_0_descriptorset\22:0,\22input_0_type\22:\22TENSOR\22,\22input_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22input_0_vkformat\22:\22VK_FORMAT_R32_SINT\22,\22output_0_binding\22:1,\22output_0_descriptorset\22:0,\22output_0_type\22:\22TENSOR\22,\22output_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22output_0_vkformat\22:\22VK_FORMAT_R32_SINT\22}", operator_name = "second_shader"} : (tensor<4xi32>) -> tensor<4xi32>
+  %out = tosa.add %shader_1, %flow_i32 : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi32>
+  return %out : tensor<4xi32>
+}
+
+// -----
+
+func.func @equal_width_rescale_not_rematerialized(%arg0: tensor<4xi16> {tf_saved_model.index_path = ["input_0"]}) -> (tensor<4xi16> {tf_saved_model.index_path = ["output_0"]}) attributes {tf.entry_function = {inputs = "input_0", outputs = "output_0"}} {
+  // CHECK-LABEL: vgf.sequence @equal_width_rescale_not_rematerialized
+  // CHECK: func.func @graph_partition_0(%{{[^:]+}}: tensor<4xi16>) -> tensor<4xi16>
+  // CHECK: tosa.rescale
+  // CHECK: vgf.segment @graph_partition_1
+  // CHECK: func.func @graph_partition_2(%{{[^:]+}}: tensor<4xi16>, %{{[^:]+}}: tensor<4xi16>) -> tensor<4xi16>
+  // CHECK-NOT: tosa.rescale
+  // CHECK: tosa.add
+  %multiplier = "tosa.const"() {values = dense<[1]> : tensor<1xi32>} : () -> tensor<1xi32>
+  %shift = "tosa.const"() {values = dense<[0]> : tensor<1xi8>} : () -> tensor<1xi8>
+  %zero_point = "tosa.const"() {values = dense<[0]> : tensor<1xi16>} : () -> tensor<1xi16>
+  %rescaled = tosa.rescale %arg0, %multiplier, %shift, %zero_point, %zero_point {rounding_mode = SINGLE_ROUND, per_channel = false, scale32 = true, input_unsigned = false, output_unsigned = false} : (tensor<4xi16>, tensor<1xi32>, tensor<1xi8>, tensor<1xi16>, tensor<1xi16>) -> tensor<4xi16>
+  %shader = tosa.custom %arg0 {domain_name = "com.arm.VulkanCustomShader", implementation_attrs = "{\22entry_point\22:\22main\22,\22is_vkshader\22:true,\22workgroup_sizes\22:[1,1,1],\22input_0_binding\22:0,\22input_0_descriptorset\22:0,\22input_0_type\22:\22TENSOR\22,\22input_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22input_0_vkformat\22:\22VK_FORMAT_R16_SINT\22,\22output_0_binding\22:1,\22output_0_descriptorset\22:0,\22output_0_type\22:\22TENSOR\22,\22output_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22output_0_vkformat\22:\22VK_FORMAT_R16_SINT\22}", operator_name = "equal_width_shader"} : (tensor<4xi16>) -> tensor<4xi16>
+  %out = tosa.add %shader, %rescaled : (tensor<4xi16>, tensor<4xi16>) -> tensor<4xi16>
+  return %out : tensor<4xi16>
+}
+
+// -----
+
+func.func @narrowing_rescale_not_rematerialized(%arg0: tensor<4xi16> {tf_saved_model.index_path = ["input_0"]}) -> (tensor<4xi8> {tf_saved_model.index_path = ["output_0"]}) attributes {tf.entry_function = {inputs = "input_0", outputs = "output_0"}} {
+  // CHECK-LABEL: vgf.sequence @narrowing_rescale_not_rematerialized
+  // CHECK: func.func @graph_partition_0(%{{[^:]+}}: tensor<4xi16>) -> tensor<4xi8>
+  // CHECK: tosa.rescale
+  // CHECK: vgf.segment @graph_partition_1
+  // CHECK: func.func @graph_partition_2(%{{[^:]+}}: tensor<4xi8>, %{{[^:]+}}: tensor<4xi8>) -> tensor<4xi8>
+  // CHECK-NOT: tosa.rescale
+  // CHECK: tosa.add
+  %multiplier = "tosa.const"() {values = dense<[1]> : tensor<1xi32>} : () -> tensor<1xi32>
+  %shift = "tosa.const"() {values = dense<[0]> : tensor<1xi8>} : () -> tensor<1xi8>
+  %input_zp = "tosa.const"() {values = dense<[0]> : tensor<1xi16>} : () -> tensor<1xi16>
+  %output_zp = "tosa.const"() {values = dense<[0]> : tensor<1xi8>} : () -> tensor<1xi8>
+  %rescaled = tosa.rescale %arg0, %multiplier, %shift, %input_zp, %output_zp {rounding_mode = SINGLE_ROUND, per_channel = false, scale32 = true, input_unsigned = false, output_unsigned = false} : (tensor<4xi16>, tensor<1xi32>, tensor<1xi8>, tensor<1xi16>, tensor<1xi8>) -> tensor<4xi8>
+  %shader = tosa.custom %arg0 {domain_name = "com.arm.VulkanCustomShader", implementation_attrs = "{\22entry_point\22:\22main\22,\22is_vkshader\22:true,\22workgroup_sizes\22:[1,1,1],\22input_0_binding\22:0,\22input_0_descriptorset\22:0,\22input_0_type\22:\22TENSOR\22,\22input_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22input_0_vkformat\22:\22VK_FORMAT_R16_SINT\22,\22output_0_binding\22:1,\22output_0_descriptorset\22:0,\22output_0_type\22:\22TENSOR\22,\22output_0_vkdescriptortype\22:\22VK_DESCRIPTOR_TYPE_TENSOR_ARM\22,\22output_0_vkformat\22:\22VK_FORMAT_R8_SINT\22}", operator_name = "narrowing_shader"} : (tensor<4xi16>) -> tensor<4xi8>
+  %out = tosa.add %shader, %rescaled : (tensor<4xi8>, tensor<4xi8>) -> tensor<4xi8>
+  return %out : tensor<4xi8>
+}

--- a/test/test_model_converter_resources_v100.py
+++ b/test/test_model_converter_resources_v100.py
@@ -2,12 +2,15 @@
 # SPDX-FileCopyrightText: Copyright 2023-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
+import json
+
 import pytest
 import vgfpy
 from model_converter_helpers import converted_mlir
 from vgf_decoder import VK_FORMAT_R16_SFLOAT_FPENCODING_BFLOAT16_ARM
 from vgf_decoder import VK_FORMAT_R16_SINT
 from vgf_decoder import VK_FORMAT_R16_UINT
+from vgf_decoder import VK_FORMAT_R32_SINT
 from vgf_decoder import VK_FORMAT_R8_SFLOAT_FPENCODING_FLOAT8E4M3_ARM
 from vgf_decoder import VK_FORMAT_R8_SFLOAT_FPENCODING_FLOAT8E5M2_ARM
 from vgf_decoder import VK_FORMAT_R8_SINT
@@ -37,7 +40,87 @@ module {{
     return %4 : tensor<1x1xi16>
   }}
 }}
+    """
+
+
+def custom_shader_attrs(vk_format):
+    return json.dumps(
+        json.dumps(
+            {
+                "entry_point": "main",
+                "is_vkshader": True,
+                "workgroup_sizes": [1, 1, 1],
+                "input_0_binding": 0,
+                "input_0_descriptorset": 0,
+                "input_0_type": "TENSOR",
+                "input_0_vkdescriptortype": "VK_DESCRIPTOR_TYPE_TENSOR_ARM",
+                "input_0_vkformat": vk_format,
+                "output_0_binding": 1,
+                "output_0_descriptorset": 0,
+                "output_0_type": "TENSOR",
+                "output_0_vkdescriptortype": "VK_DESCRIPTOR_TYPE_TENSOR_ARM",
+                "output_0_vkformat": vk_format,
+            },
+            separators=(",", ":"),
+        )
+    )
+
+
+def boundary_rescale_rematerialized_mlir():
+    attrs = custom_shader_attrs("VK_FORMAT_R8_SINT")
+    return f"""
+module {{
+  func.func @main(%arg0: tensor<4xi8> {{tf_saved_model.index_path = ["input_0"]}}) -> (tensor<4xi32> {{tf_saved_model.index_path = ["output_0"]}}) attributes {{tf.entry_function = {{inputs = "input_0", outputs = "output_0"}}, tf_saved_model.exported_names = ["main"]}} {{
+    %multiplier = "tosa.const"() {{values = dense<[1]> : tensor<1xi32>}} : () -> tensor<1xi32>
+    %shift = "tosa.const"() {{values = dense<[0]> : tensor<1xi8>}} : () -> tensor<1xi8>
+    %input_zp = "tosa.const"() {{values = dense<[0]> : tensor<1xi8>}} : () -> tensor<1xi8>
+    %flow_output_zp = "tosa.const"() {{values = dense<[0]> : tensor<1xi8>}} : () -> tensor<1xi8>
+    %output_zp = "tosa.const"() {{values = dense<[0]> : tensor<1xi32>}} : () -> tensor<1xi32>
+    %flow = tosa.rescale %arg0, %multiplier, %shift, %input_zp, %flow_output_zp {{rounding_mode = SINGLE_ROUND, per_channel = false, scale32 = true, input_unsigned = false, output_unsigned = false}} : (tensor<4xi8>, tensor<1xi32>, tensor<1xi8>, tensor<1xi8>, tensor<1xi8>) -> tensor<4xi8>
+    %old_flow_i32 = tosa.rescale %flow, %multiplier, %shift, %input_zp, %output_zp {{rounding_mode = SINGLE_ROUND, per_channel = false, scale32 = true, input_unsigned = false, output_unsigned = false}} : (tensor<4xi8>, tensor<1xi32>, tensor<1xi8>, tensor<1xi8>, tensor<1xi32>) -> tensor<4xi32>
+    %shader = tosa.custom %flow {{domain_name = "com.arm.VulkanCustomShader", implementation_attrs = {attrs}, operator_name = "remat_shader"}} : (tensor<4xi8>) -> tensor<4xi8>
+    %shader_i32 = tosa.rescale %shader, %multiplier, %shift, %input_zp, %output_zp {{rounding_mode = SINGLE_ROUND, per_channel = false, scale32 = true, input_unsigned = false, output_unsigned = false}} : (tensor<4xi8>, tensor<1xi32>, tensor<1xi8>, tensor<1xi8>, tensor<1xi32>) -> tensor<4xi32>
+    %out = tosa.add %shader_i32, %old_flow_i32 : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi32>
+    return %out : tensor<4xi32>
+  }}
+}}
 """
+
+
+def boundary_rescale_compute_use_preserved_mlir():
+    attrs = custom_shader_attrs("VK_FORMAT_R32_SINT")
+    return f"""
+module {{
+  func.func @main(%arg0: tensor<4xi8> {{tf_saved_model.index_path = ["input_0"]}}) -> (tensor<4xi32> {{tf_saved_model.index_path = ["output_0"]}}) attributes {{tf.entry_function = {{inputs = "input_0", outputs = "output_0"}}, tf_saved_model.exported_names = ["main"]}} {{
+    %multiplier = "tosa.const"() {{values = dense<[1]> : tensor<1xi32>}} : () -> tensor<1xi32>
+    %shift = "tosa.const"() {{values = dense<[0]> : tensor<1xi8>}} : () -> tensor<1xi8>
+    %input_zp = "tosa.const"() {{values = dense<[0]> : tensor<1xi8>}} : () -> tensor<1xi8>
+    %flow_output_zp = "tosa.const"() {{values = dense<[0]> : tensor<1xi8>}} : () -> tensor<1xi8>
+    %output_zp = "tosa.const"() {{values = dense<[0]> : tensor<1xi32>}} : () -> tensor<1xi32>
+    %flow = tosa.rescale %arg0, %multiplier, %shift, %input_zp, %flow_output_zp {{rounding_mode = SINGLE_ROUND, per_channel = false, scale32 = true, input_unsigned = false, output_unsigned = false}} : (tensor<4xi8>, tensor<1xi32>, tensor<1xi8>, tensor<1xi8>, tensor<1xi8>) -> tensor<4xi8>
+    %old_flow_i32 = tosa.rescale %flow, %multiplier, %shift, %input_zp, %output_zp {{rounding_mode = SINGLE_ROUND, per_channel = false, scale32 = true, input_unsigned = false, output_unsigned = false}} : (tensor<4xi8>, tensor<1xi32>, tensor<1xi8>, tensor<1xi8>, tensor<1xi32>) -> tensor<4xi32>
+    %shader = tosa.custom %old_flow_i32 {{domain_name = "com.arm.VulkanCustomShader", implementation_attrs = {attrs}, operator_name = "i32_shader"}} : (tensor<4xi32>) -> tensor<4xi32>
+    %out = tosa.add %shader, %old_flow_i32 : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi32>
+    return %out : tensor<4xi32>
+  }}
+}}
+"""
+
+
+def binding_slots_by_binding(vgf, bindings_handle):
+    return {
+        vgf.sequence.getBindingSlotBinding(bindings_handle, binding_index): (
+            vgf.sequence.getBindingSlotMrtIndex(bindings_handle, binding_index)
+        )
+        for binding_index in range(vgf.sequence.getBindingsSize(bindings_handle))
+    }
+
+
+def resource_formats(vgf, binding_slots):
+    return [
+        int(vgf.resources.getVkFormat(index))
+        for _, index in sorted(binding_slots.items())
+    ]
 
 
 @pytest.mark.parametrize(
@@ -65,6 +148,65 @@ def test_rescale_signless_integer_resource_formats(
         assert int(vgf.resources.getVkFormat(0)) == expected_input_format
         assert vgf.resources.getCategory(1) == vgfpy.ResourceCategory.Output
         assert int(vgf.resources.getVkFormat(1)) == expected_output_format
+
+
+def test_boundary_rescale_rematerialization_uses_i8_graph_resource(
+    model_converter_exe_path,
+):
+    with converted_mlir(
+        model_converter_exe_path,
+        boundary_rescale_rematerialized_mlir(),
+    ) as vgf:
+        assert vgf.sequence.modelSequenceTableSize() == 3
+        assert vgf.sequence.getSegmentType(0) == vgfpy.ModuleType.Graph
+        assert vgf.sequence.getSegmentType(1) == vgfpy.ModuleType.Compute
+        assert vgf.sequence.getSegmentType(2) == vgfpy.ModuleType.Graph
+
+        graph0_outputs = binding_slots_by_binding(
+            vgf, vgf.sequence.getSegmentOutputBindingSlotsHandle(0)
+        )
+        graph2_inputs = binding_slots_by_binding(
+            vgf, vgf.sequence.getSegmentInputBindingSlotsHandle(2)
+        )
+
+        assert resource_formats(vgf, graph0_outputs) == [VK_FORMAT_R8_SINT]
+        assert resource_formats(vgf, graph2_inputs) == [
+            VK_FORMAT_R8_SINT,
+            VK_FORMAT_R8_SINT,
+        ]
+
+
+def test_boundary_rescale_compute_i32_resource_is_preserved(
+    model_converter_exe_path,
+):
+    with converted_mlir(
+        model_converter_exe_path,
+        boundary_rescale_compute_use_preserved_mlir(),
+    ) as vgf:
+        assert vgf.sequence.modelSequenceTableSize() == 3
+        assert vgf.sequence.getSegmentType(0) == vgfpy.ModuleType.Graph
+        assert vgf.sequence.getSegmentType(1) == vgfpy.ModuleType.Compute
+        assert vgf.sequence.getSegmentType(2) == vgfpy.ModuleType.Graph
+
+        graph0_outputs = binding_slots_by_binding(
+            vgf, vgf.sequence.getSegmentOutputBindingSlotsHandle(0)
+        )
+        compute_inputs = binding_slots_by_binding(
+            vgf, vgf.sequence.getSegmentInputBindingSlotsHandle(1)
+        )
+        graph2_inputs = binding_slots_by_binding(
+            vgf, vgf.sequence.getSegmentInputBindingSlotsHandle(2)
+        )
+
+        assert resource_formats(vgf, graph0_outputs) == [
+            VK_FORMAT_R8_SINT,
+            VK_FORMAT_R32_SINT,
+        ]
+        assert resource_formats(vgf, compute_inputs) == [VK_FORMAT_R32_SINT]
+        assert resource_formats(vgf, graph2_inputs) == [
+            VK_FORMAT_R8_SINT,
+            VK_FORMAT_R32_SINT,
+        ]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Keep graph dispatch boundaries at the narrow producer dtype when a widened TOSA RESCALE is only needed by a later graph partition. Clone the RESCALE into each consuming graph segment instead of exporting the widened tensor as an intermediate resource.

This avoids full-resolution R32_SINT graph resources for quantized carry tensors while preserving compute-shader contracts and model outputs that explicitly require the widened dtype.




Change-Id: I90cfc169ed403253451887114019ef0717a1bd61