### PR TITLE
refactor: Simplify VGF builder ownership

### DIFF
--- a/src/conversion/resource_planner.cpp
+++ b/src/conversion/resource_planner.cpp
@@ -80,7 +80,7 @@ std::optional<SamplerConfigValues> getOptionalSamplerConfigValues(ArrayAttr samp
 
 const std::vector<BindingSlotRef> &
 getSegmentBindings(const std::map<SegmentId, std::vector<BindingSlotRef>> &bindingsBySegment, SegmentId segmentId) {
-    static const std::vector<BindingSlotRef> emptyBindings = {};
+    static const std::vector<BindingSlotRef> emptyBindings;
     auto bindingsIt = bindingsBySegment.find(segmentId);
     if (bindingsIt == bindingsBySegment.end()) {
         return emptyBindings;
@@ -600,13 +600,13 @@ void ResourcePlanEncoder::addBindingToDescriptorSet(SegmentId segmentId, int64_t
 ResourceRef ResourcePlanEncoder::createResource(const PlannedValue &plan, const ResourceKey &resourceKey) {
     switch (resourceKey.category) {
     case ResourceCategory::INPUT:
-        return _vgfBuilder.getEncoder()->AddInputResource(resourceKey.view.descriptorType, resourceKey.view.vkFormat,
-                                                          plan.shape, {}, plan.aliasGroupId);
+        return _vgfBuilder.getEncoder().AddInputResource(resourceKey.view.descriptorType, resourceKey.view.vkFormat,
+                                                         plan.shape, {}, plan.aliasGroupId);
     case ResourceCategory::OUTPUT:
-        return _vgfBuilder.getEncoder()->AddOutputResource(resourceKey.view.descriptorType, resourceKey.view.vkFormat,
-                                                           plan.shape, {}, plan.aliasGroupId);
+        return _vgfBuilder.getEncoder().AddOutputResource(resourceKey.view.descriptorType, resourceKey.view.vkFormat,
+                                                          plan.shape, {}, plan.aliasGroupId);
     case ResourceCategory::INTERMEDIATE:
-        return _vgfBuilder.getEncoder()->AddIntermediateResource(
+        return _vgfBuilder.getEncoder().AddIntermediateResource(
             resourceKey.view.descriptorType, resourceKey.view.vkFormat, plan.shape, {}, plan.aliasGroupId);
     case ResourceCategory::CONSTANT:
         assert(false && "planned VGF resources must not be constants");
@@ -622,9 +622,9 @@ void ResourcePlanEncoder::addSamplerConfig(ResourceRef resourceRef, const Resour
     }
 
     const auto &samplerConfig = *resourceKey.samplerConfig;
-    _vgfBuilder.getEncoder()->AddSamplerConfig(resourceRef, samplerConfig.minFilter, samplerConfig.magFilter,
-                                               samplerConfig.addressModeU, samplerConfig.addressModeV,
-                                               samplerConfig.borderColor);
+    _vgfBuilder.getEncoder().AddSamplerConfig(resourceRef, samplerConfig.minFilter, samplerConfig.magFilter,
+                                              samplerConfig.addressModeU, samplerConfig.addressModeV,
+                                              samplerConfig.borderColor);
 }
 
 ResourceRef ResourcePlanEncoder::getOrCreateResource(Value value, const ResourceKey &resourceKey) {
@@ -652,7 +652,7 @@ BindingSlotRef ResourcePlanEncoder::getOrCreateLogicalBindingSlot(Value value, c
     auto bindingSlotIt = encodedValue.logicalBindingSlots.find(resourceKey);
     if (bindingSlotIt == encodedValue.logicalBindingSlots.end()) {
         bindingSlotIt = encodedValue.logicalBindingSlots
-                            .emplace(resourceKey, _vgfBuilder.getEncoder()->AddBindingSlot(
+                            .emplace(resourceKey, _vgfBuilder.getEncoder().AddBindingSlot(
                                                       plan.bindingIndex, getOrCreateResource(value, resourceKey)))
                             .first;
     }
@@ -670,8 +670,7 @@ BindingSlotRef ResourcePlanEncoder::getOrCreateDescriptorBindingSlot(Value value
     if (bindingSlotIt == encodedValue.descriptorBindingSlots.end()) {
         bindingSlotIt =
             encodedValue.descriptorBindingSlots
-                .emplace(key,
-                         _vgfBuilder.getEncoder()->AddBindingSlot(binding, getOrCreateResource(value, resourceKey)))
+                .emplace(key, _vgfBuilder.getEncoder().AddBindingSlot(binding, getOrCreateResource(value, resourceKey)))
                 .first;
     }
 

--- a/src/conversion/serialize_vgf.cpp
+++ b/src/conversion/serialize_vgf.cpp
@@ -72,8 +72,8 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
     mlir::LogicalResult serializeModule(mlir::vgf::SequenceOp &sequenceOp) {
 
         // Fetch input/output names if available
-        std::vector<std::string> inputNames = {};
-        std::vector<std::string> outputNames = {};
+        std::vector<std::string> inputNames;
+        std::vector<std::string> outputNames;
 
         if (auto tfEntryFunctionAttr = sequenceOp->getAttrDictionary().getAs<DictionaryAttr>("tf.entry_function")) {
             if (auto inputsAttr = tfEntryFunctionAttr.getAs<StringAttr>("inputs")) {
@@ -117,7 +117,7 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
             const auto &segmentOutputBindings = encodedResourcePlan.getSegmentOutputBindings(segmentId);
 
             WalkResult segmentWalkResult;
-            std::vector<BindingSlotRef> segmentAllBindings = {};
+            std::vector<BindingSlotRef> segmentAllBindings;
             if (segmentType == vgf::SegmentTypeEnum::COMPUTE) {
                 segmentWalkResult = segmentOp.walk([&](vgf::ShaderPlaceholderOp shaderPlaceholderOp) {
                     // Add shader module table entry
@@ -135,14 +135,14 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
                                                    shaderBinaryCodeAttr.asArrayRef().end(),
                                                    std::back_inserter(binaryCode),
                                                    [](int32_t word) { return static_cast<uint32_t>(word); });
-                                    return _VGFBuilder->getEncoder()->AddModule(
+                                    return _VGFBuilder->getEncoder().AddModule(
                                         ModuleType::COMPUTE, segmentName.str(),
                                         shaderPlaceholderOp.getEntryPointAttr().str(), binaryCode);
                                 }
                             } else if (auto shaderSourceAttr = llvm::dyn_cast_if_present<StringAttr>(shaderCodeAttr)) {
                                 const auto shaderType = toShaderType(shaderLanguageAttr.str());
                                 if (shaderType.has_value()) {
-                                    return _VGFBuilder->getEncoder()->AddModule(
+                                    return _VGFBuilder->getEncoder().AddModule(
                                         ModuleType::COMPUTE, segmentName.str(),
                                         shaderPlaceholderOp.getEntryPointAttr().str(), shaderType.value(),
                                         shaderSourceAttr.str());
@@ -150,17 +150,17 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
                             }
                         }
 
-                        return _VGFBuilder->getEncoder()->AddModule(ModuleType::COMPUTE, segmentName.str(),
-                                                                    shaderPlaceholderOp.getEntryPointAttr().str());
+                        return _VGFBuilder->getEncoder().AddModule(ModuleType::COMPUTE, segmentName.str(),
+                                                                   shaderPlaceholderOp.getEntryPointAttr().str());
                     }();
 
                     const auto descriptorSetInfos = [&]() {
-                        std::vector<DescriptorSetInfoRef> descriptorSetInfos = {};
+                        std::vector<DescriptorSetInfoRef> descriptorSetInfos;
                         auto descriptorSetBindingsIt = encodedResourcePlan.segmentDescriptorSetBindings.find(segmentId);
                         if (descriptorSetBindingsIt != encodedResourcePlan.segmentDescriptorSetBindings.end()) {
                             for (const auto &[descriptorSetIndex, bindings] : descriptorSetBindingsIt->second) {
                                 descriptorSetInfos.push_back(
-                                    _VGFBuilder->getEncoder()->AddDescriptorSetInfo(bindings, descriptorSetIndex));
+                                    _VGFBuilder->getEncoder().AddDescriptorSetInfo(bindings, descriptorSetIndex));
                             }
                         }
                         return descriptorSetInfos;
@@ -172,7 +172,7 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
                                                                    static_cast<uint32_t>(workgroupSizes[1]),
                                                                    static_cast<uint32_t>(workgroupSizes[2])};
 
-                    _VGFBuilder->getEncoder()->AddSegmentInfo(
+                    _VGFBuilder->getEncoder().AddSegmentInfo(
                         computeModuleRef, "compute_segment_" + std::to_string(computeSegmentId++), descriptorSetInfos,
                         segmentInputBindings, segmentOutputBindings, {}, dispatchShape);
 
@@ -194,8 +194,8 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
 
                     // Add graph module table entry
                     ModuleRef graphModuleRef =
-                        _VGFBuilder->getEncoder()->AddModule(ModuleType::GRAPH, segmentName.str(), entryPointName,
-                                                             std::vector<uint32_t>(binary.begin(), binary.end()));
+                        _VGFBuilder->getEncoder().AddModule(ModuleType::GRAPH, segmentName.str(), entryPointName,
+                                                            std::vector<uint32_t>(binary.begin(), binary.end()));
 
                     WalkResult spirvModuleWalkResult = spirvModuleOp.walk([&](spirv::GraphARMOp) {
                         std::copy(segmentInputBindings.cbegin(), segmentInputBindings.cend(),
@@ -204,10 +204,10 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
                                   std::back_inserter(segmentAllBindings));
 
                         const DescriptorSetInfoRef descSetInfo =
-                            _VGFBuilder->getEncoder()->AddDescriptorSetInfo(segmentAllBindings);
+                            _VGFBuilder->getEncoder().AddDescriptorSetInfo(segmentAllBindings);
                         const auto segmentConstants = getSegmentConstantRefs(spirvModuleOp);
 
-                        _VGFBuilder->getEncoder()->AddSegmentInfo(
+                        _VGFBuilder->getEncoder().AddSegmentInfo(
                             graphModuleRef, "graph_segment_" + std::to_string(graphSegmentId++), {descSetInfo},
                             segmentInputBindings, segmentOutputBindings, segmentConstants);
 
@@ -226,9 +226,9 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
             return failure();
         }
 
-        _VGFBuilder->getEncoder()->AddModelSequenceInputsOutputs(encodedResourcePlan.sequenceInputBindings, inputNames,
-                                                                 encodedResourcePlan.sequenceOutputBindings,
-                                                                 outputNames);
+        _VGFBuilder->getEncoder().AddModelSequenceInputsOutputs(encodedResourcePlan.sequenceInputBindings, inputNames,
+                                                                encodedResourcePlan.sequenceOutputBindings,
+                                                                outputNames);
         return success();
     }
 
@@ -238,10 +238,10 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
             return failure();
         }
 
-        _VGFBuilder->getEncoder()->Finish();
+        _VGFBuilder->getEncoder().Finish();
 
         if (_outputName == "-") {
-            if (!_VGFBuilder->getEncoder()->WriteTo(std::cout)) {
+            if (!_VGFBuilder->getEncoder().WriteTo(std::cout)) {
                 llvm::errs() << "Unable to write to stdout\n";
                 return failure();
             }
@@ -254,7 +254,7 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
             return failure();
         }
 
-        if (!_VGFBuilder->getEncoder()->WriteTo(fstream)) {
+        if (!_VGFBuilder->getEncoder().WriteTo(fstream)) {
             llvm::errs() << "Error writing to file\n";
             return failure();
         }
@@ -264,16 +264,16 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
         return success();
     }
 
-    std::shared_ptr<VGFBuilder> _VGFBuilder = {nullptr};
+    std::shared_ptr<VGFBuilder> _VGFBuilder;
     std::string _outputName;
     bool _emitDebugInfo;
 };
 
 } // namespace
 
-std::unique_ptr<Pass> createSerializeVGFPass(std::shared_ptr<VGFBuilder> VGFBuilder, std::string outputName,
+std::unique_ptr<Pass> createSerializeVGFPass(std::shared_ptr<VGFBuilder> vgfBuilder, std::string outputName,
                                              const SerializeVGFPassOptions &options) {
-    return std::make_unique<SerializeVGFPass>(VGFBuilder, outputName, options);
+    return std::make_unique<SerializeVGFPass>(std::move(vgfBuilder), std::move(outputName), options);
 }
 
 } // namespace mlir::model_converter_passes

--- a/src/conversion/vgf_constants.cpp
+++ b/src/conversion/vgf_constants.cpp
@@ -35,8 +35,8 @@ class VGFConstantsPass : public impl::VGFConstantsPassBase<VGFConstantsPass> {
   private:
     template <typename T> void serializeConstantData(T &attr, ResourceRef resource, int64_t sparsityDimension = -1) {
         mlir::AccessData(attr, [&](const char *data, size_t size) {
-            ConstantRef constRef = _VGFBuilder->getEncoder()->AddConstant(resource, data, size, sparsityDimension);
-            _VGFBuilder->AddConstantRef(constRef);
+            ConstantRef constRef = _VGFBuilder->getEncoder().AddConstant(resource, data, size, sparsityDimension);
+            _VGFBuilder->addConstantRef(constRef);
         });
     }
 
@@ -72,13 +72,13 @@ class VGFConstantsPass : public impl::VGFConstantsPassBase<VGFConstantsPass> {
 
             const ShapedType type = convertShapedType(constOp.getResult().getType());
             VGFBuilder::VkFormat vkFormat;
-            if (_VGFBuilder->mlirTypeToVkFormat(type.getElementType(), vkFormat, checkIfUnsignedRequired(constOp))
+            if (VGFBuilder::mlirTypeToVkFormat(type.getElementType(), vkFormat, checkIfUnsignedRequired(constOp))
                     .failed()) {
                 return constOp.emitError("unsupported type for tosa.const op: ") << type.getElementType();
             }
 
             auto format = static_cast<FormatType>(vkFormat);
-            ResourceRef resourceRef = _VGFBuilder->getEncoder()->AddConstantResource(format, type.getShape(), {});
+            ResourceRef resourceRef = _VGFBuilder->getEncoder().AddConstantResource(format, type.getShape(), {});
 
             int64_t sparsityDimension = -1;
             auto attr = constOp->getAttrOfType<IntegerAttr>("constant_2_4_sparse_on_dimension");
@@ -99,8 +99,8 @@ class VGFConstantsPass : public impl::VGFConstantsPassBase<VGFConstantsPass> {
 
 } // namespace
 
-std::unique_ptr<Pass> createVGFConstantsPass(std::shared_ptr<VGFBuilder> VGFBuilder) {
-    return std::make_unique<VGFConstantsPass>(VGFBuilder);
+std::unique_ptr<Pass> createVGFConstantsPass(std::shared_ptr<VGFBuilder> vgfBuilder) {
+    return std::make_unique<VGFConstantsPass>(std::move(vgfBuilder));
 }
 
 } // namespace mlir::model_converter_passes

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,7 +48,7 @@ bool validateCustomOpDomainToOpcode(const std::vector<std::string> &mappings) {
 }
 
 std::unique_ptr<argparse::ArgumentParser> createParser(int argc, const char *argv[]) {
-    std::unique_ptr<argparse::ArgumentParser> parser = nullptr;
+    std::unique_ptr<argparse::ArgumentParser> parser;
     try {
         parser = std::make_unique<argparse::ArgumentParser>(argv[0], details::version);
 
@@ -140,7 +140,6 @@ int main(int argc, const char *argv[]) {
     std::string input;
     Compiler::Options options;
     options.enable_verifier = true;
-    options.enable_statistics = false;
 
     try {
         input = parser->get("--input");

--- a/src/vgf_builder.hpp
+++ b/src/vgf_builder.hpp
@@ -10,16 +10,14 @@
 #include <algorithm>
 #include <cstdint>
 #include <iterator>
+#include <memory>
 #include <vector>
 
 namespace mlsdk::model_converter {
 
 class VGFBuilder {
   public:
-    ~VGFBuilder(){};
-    VGFBuilder() : _encoder(mlsdk::vgflib::CreateEncoder(0)) {}
-    std::shared_ptr<mlsdk::vgflib::Encoder> getEncoder() const { return _encoder; }
-    const std::vector<mlsdk::vgflib::ConstantRef> &getConstantRefs() const { return _constantRefs; }
+    mlsdk::vgflib::Encoder &getEncoder() { return *_encoder; }
 
     std::vector<mlsdk::vgflib::ConstantRef> getConstantRefs(const std::vector<uint32_t> &ids) const {
         std::vector<mlsdk::vgflib::ConstantRef> refs;
@@ -29,7 +27,7 @@ class VGFBuilder {
         return refs;
     }
 
-    void AddConstantRef(mlsdk::vgflib::ConstantRef constRef) { _constantRefs.emplace_back(constRef); }
+    void addConstantRef(mlsdk::vgflib::ConstantRef constRef) { _constantRefs.push_back(constRef); }
 
     // We only support a small handful of Formats for now so redefine the ones
     // we need as it's simpler than adding a dependency on Vulkan-Headers.
@@ -103,7 +101,7 @@ class VGFBuilder {
     }
 
   private:
-    std::shared_ptr<mlsdk::vgflib::Encoder> _encoder;
+    std::unique_ptr<mlsdk::vgflib::Encoder> _encoder = mlsdk::vgflib::CreateEncoder(0);
     std::vector<mlsdk::vgflib::ConstantRef> _constantRefs;
 };
 


### PR DESCRIPTION
Keep the VGF encoder uniquely owned by VGFBuilder and expose it through a borrowed reference. This matches the CreateEncoder ownership contract and avoids unnecessary shared-pointer reference counting.

Remove redundant default initializers while updating the affected call sites.

Change-Id: If4383865e9bb8c8222ccac10ea0066daf5b7e8aa