### PR TITLE
feat: serialize graph constant bindings

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,7 +11,13 @@
   graph partitions.
 
 ### Build, Packaging & Developer Experience
- - Updated Model Converter `--version` output to report the package version and include git revision and dependency revision information
+
+- Updated Model Converter `--version` output to report the package version and
+  include git revision and dependency revision information.
+
+### Converter & Toolchain
+
+- Added VGF serialization support for explicit graph constant bindings.
 
 ### Features
  - VGF file output now supports dynamic dimension sizes

--- a/src/conversion/serialize_vgf.cpp
+++ b/src/conversion/serialize_vgf.cpp
@@ -60,13 +60,13 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
     }
 
   private:
-    std::vector<ConstantRef> getSegmentConstantRefs(spirv::ModuleOp spirvModuleOp) const {
+    std::vector<GraphConstantBindingRef> getSegmentConstantBindings(spirv::ModuleOp spirvModuleOp) const {
         std::vector<uint32_t> ids;
         spirvModuleOp.walk(
             [&](spirv::GraphConstantARMOp graphConstantOp) { ids.push_back(graphConstantOp.getGraphConstantId()); });
         std::sort(ids.begin(), ids.end());
         ids.erase(std::unique(ids.begin(), ids.end()), ids.end());
-        return _VGFBuilder->getConstantRefs(ids);
+        return _VGFBuilder->getConstantBindings(ids);
     }
 
     mlir::LogicalResult serializeModule(mlir::vgf::SequenceOp &sequenceOp) {
@@ -174,7 +174,8 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
 
                     _VGFBuilder->getEncoder().AddSegmentInfo(
                         computeModuleRef, "compute_segment_" + std::to_string(computeSegmentId++), descriptorSetInfos,
-                        segmentInputBindings, segmentOutputBindings, {}, dispatchShape);
+                        segmentInputBindings, segmentOutputBindings, std::vector<GraphConstantBindingRef>{},
+                        dispatchShape);
 
                     return WalkResult::advance();
                 });
@@ -205,7 +206,7 @@ class SerializeVGFPass : public impl::SerializeVGFPassBase<SerializeVGFPass> {
 
                         const DescriptorSetInfoRef descSetInfo =
                             _VGFBuilder->getEncoder().AddDescriptorSetInfo(segmentAllBindings);
-                        const auto segmentConstants = getSegmentConstantRefs(spirvModuleOp);
+                        const auto segmentConstants = getSegmentConstantBindings(spirvModuleOp);
 
                         _VGFBuilder->getEncoder().AddSegmentInfo(
                             graphModuleRef, "graph_segment_" + std::to_string(graphSegmentId++), {descSetInfo},

--- a/src/conversion/vgf_constants.cpp
+++ b/src/conversion/vgf_constants.cpp
@@ -34,10 +34,12 @@ class VGFConstantsPass : public impl::VGFConstantsPassBase<VGFConstantsPass> {
     }
 
   private:
-    template <typename T> void serializeConstantData(T &attr, ResourceRef resource, int64_t sparsityDimension = -1) {
+    template <typename T>
+    void serializeConstantData(uint32_t graphConstantId, T &attr, ResourceRef resource,
+                               int64_t sparsityDimension = -1) {
         mlir::AccessData(attr, [&](const char *data, size_t size) {
             ConstantRef constRef = _VGFBuilder->getEncoder().AddConstant(resource, data, size, sparsityDimension);
-            _VGFBuilder->addConstantRef(constRef);
+            _VGFBuilder->AddConstantBinding(graphConstantId, constRef);
         });
     }
 
@@ -64,13 +66,7 @@ class VGFConstantsPass : public impl::VGFConstantsPassBase<VGFConstantsPass> {
             }
         });
 
-        uint32_t expectedId = 0;
         for (auto &[id, constOp] : constantsById) {
-            if (id != expectedId) {
-                return constOp.emitError("missing TOSA graph constant id ")
-                       << expectedId << "; VGF constants must be serialized in global graph constant id order";
-            }
-
             const ShapedType type = convertShapedType(constOp.getResult().getType());
             VGFBuilder::VkFormat vkFormat;
             if (VGFBuilder::mlirTypeToVkFormat(type.getElementType(), vkFormat, checkIfUnsignedRequired(constOp))
@@ -89,8 +85,7 @@ class VGFConstantsPass : public impl::VGFConstantsPassBase<VGFConstantsPass> {
             }
 
             auto attrVal = llvm::dyn_cast<DenseTypedElementsAttr>(constOp.getValuesAttr());
-            serializeConstantData(attrVal, resourceRef, sparsityDimension);
-            ++expectedId;
+            serializeConstantData(id, attrVal, resourceRef, sparsityDimension);
         }
 
         return mlir::success();

--- a/src/vgf_builder.hpp
+++ b/src/vgf_builder.hpp
@@ -10,7 +10,9 @@
 #include <algorithm>
 #include <cstdint>
 #include <iterator>
+#include <map>
 #include <memory>
+#include <stdexcept>
 #include <vector>
 
 namespace mlsdk::model_converter {
@@ -19,15 +21,24 @@ class VGFBuilder {
   public:
     mlsdk::vgflib::Encoder &getEncoder() { return *_encoder; }
 
-    std::vector<mlsdk::vgflib::ConstantRef> getConstantRefs(const std::vector<uint32_t> &ids) const {
-        std::vector<mlsdk::vgflib::ConstantRef> refs;
-        refs.reserve(ids.size());
-        std::transform(ids.begin(), ids.end(), std::back_inserter(refs),
-                       [this](uint32_t id) { return _constantRefs[id]; });
-        return refs;
+    std::vector<mlsdk::vgflib::GraphConstantBindingRef>
+    getConstantBindings(const std::vector<uint32_t> &graphConstantIds) const {
+        std::vector<mlsdk::vgflib::GraphConstantBindingRef> bindings;
+        bindings.reserve(graphConstantIds.size());
+        std::transform(graphConstantIds.begin(), graphConstantIds.end(), std::back_inserter(bindings),
+                       [this](uint32_t graphConstantId) {
+                           return mlsdk::vgflib::GraphConstantBindingRef{graphConstantId,
+                                                                         _constantRefsByGraphId.at(graphConstantId)};
+                       });
+        return bindings;
     }
 
-    void addConstantRef(mlsdk::vgflib::ConstantRef constRef) { _constantRefs.push_back(constRef); }
+    void AddConstantBinding(uint32_t graphConstantId, mlsdk::vgflib::ConstantRef constantRef) {
+        const auto [_, inserted] = _constantRefsByGraphId.emplace(graphConstantId, constantRef);
+        if (!inserted) {
+            throw std::runtime_error("Duplicate graph constant ID");
+        }
+    }
 
     // We only support a small handful of Formats for now so redefine the ones
     // we need as it's simpler than adding a dependency on Vulkan-Headers.
@@ -102,7 +113,7 @@ class VGFBuilder {
 
   private:
     std::unique_ptr<mlsdk::vgflib::Encoder> _encoder = mlsdk::vgflib::CreateEncoder(0);
-    std::vector<mlsdk::vgflib::ConstantRef> _constantRefs;
+    std::map<uint32_t, mlsdk::vgflib::ConstantRef> _constantRefsByGraphId;
 };
 
 } // namespace mlsdk::model_converter

--- a/test/test_model_converter_graph_constants_v100.py
+++ b/test/test_model_converter_graph_constants_v100.py
@@ -78,20 +78,23 @@ def partitioned_table_mlir(shared_constant=False):
     )
 
 
-def graph_segment_constant_indexes(vgf):
-    segment_indexes = []
+def graph_segment_constant_bindings(vgf):
+    segment_bindings = []
     module_ids = []
     for segment_index in range(vgf.sequence.modelSequenceTableSize()):
         if vgf.sequence.getSegmentType(segment_index) != vgfpy.ModuleType.Graph:
             continue
         module_index = vgf.sequence.getSegmentModuleIndex(segment_index)
-        segment_indexes.append(
-            list(vgf.sequence.getSegmentConstantIndexes(segment_index))
+        segment_bindings.append(
+            [
+                (binding.graphConstantId, binding.constantIndex)
+                for binding in vgf.sequence.getSegmentConstantBindings(segment_index)
+            ]
         )
         module_ids.append(
             sorted(graph_constant_ids(vgf.modules.getSPIRVModuleCode(module_index)))
         )
-    return segment_indexes, module_ids
+    return segment_bindings, module_ids
 
 
 def segment_constant_indexes(vgf):
@@ -116,11 +119,11 @@ def assert_constant_table(vgf, expected_values):
 
 def test_partitioned_graph_constants_use_global_sparse_ids(model_converter_exe_path):
     with converted_mlir(model_converter_exe_path, partitioned_table_mlir()) as vgf:
-        segment_constants, module_ids = graph_segment_constant_indexes(vgf)
+        segment_bindings, module_ids = graph_segment_constant_bindings(vgf)
 
         assert_constant_table(vgf, [0, 1, 2])
         assert segment_constant_indexes(vgf) == [[0, 2], [], [1]]
-        assert segment_constants == [[0, 2], [1]]
+        assert segment_bindings == [[(0, 0), (2, 2)], [(1, 1)]]
         assert module_ids == [[0, 2], [1]]
 
 
@@ -128,9 +131,9 @@ def test_rematerialized_shared_graph_constant_serializes_once(model_converter_ex
     with converted_mlir(
         model_converter_exe_path, partitioned_table_mlir(shared_constant=True)
     ) as vgf:
-        segment_constants, module_ids = graph_segment_constant_indexes(vgf)
+        segment_bindings, module_ids = graph_segment_constant_bindings(vgf)
 
         assert_constant_table(vgf, [0, 1, 2])
         assert segment_constant_indexes(vgf) == [[0, 2], [], [0, 1]]
-        assert segment_constants == [[0, 2], [0, 1]]
+        assert segment_bindings == [[(0, 0), (2, 2)], [(0, 0), (1, 1)]]
         assert module_ids == [[0, 2], [0, 1]]


### PR DESCRIPTION
Use the VGF graph constant binding API when writing segment metadata so each SPIR-V graph constant ID is mapped explicitly to the serialized VGF constant payload.

Keep model-converter constants keyed by graph constant ID and attach only the bindings referenced by each SPIR-V module. This preserves sparse sequence-wide graph constant IDs generated before partitioning.

Change-Id: I070cec32de82109fd3fc229892dc0deeb9e9f5af