### PR TITLE
chore: Detect TOSA FlatBuffers by file identifier

### DIFF
--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -18,15 +18,29 @@
 #include "include/DeserializationPasses.h" // from @tosa_tools/mlir_translator
 #include "include/SerializationPasses.h"   // from @tosa_tools/mlir_translator
 
-#include <filesystem>
+#include <array>
+#include <fstream>
 #include <iostream>
+#include <string_view>
 
 using namespace mlir::model_converter_passes;
 
 namespace mlsdk::model_converter {
 
 namespace {
-bool isTosaFlatbuffer(const std::string &input) { return std::filesystem::path(input).extension() == ".tosa"; }
+bool isTosaFlatbuffer(const std::string &input) {
+    std::ifstream stream(input, std::ios::binary);
+
+    // Non-size-prefixed FlatBuffers store their four-byte file identifier after the
+    // four-byte root table offset. The TOSA schema declares this identifier as "TOSA".
+    std::array<char, 8> header{};
+    // Reading the complete header also rejects files shorter than eight bytes.
+    if (!stream.read(header.data(), header.size())) {
+        return false;
+    }
+
+    return std::string_view(header.data() + 4, 4) == "TOSA";
+}
 
 LogicalResult printPassOptionError(const Twine &message) {
     llvm::errs() << message << "\n";

--- a/test/test_model_converter_core_v100.py
+++ b/test/test_model_converter_core_v100.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright 2023-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
+import subprocess
+
 import pytest
 import vgfpy
 from model_converter_helpers import converted_mlir
@@ -116,6 +118,37 @@ def direct_passthrough_mlir():
         body="",
         return_value="%arg0 : tensor<49x38x55xi16>",
     )
+
+
+def test_tosa_flatbuffer_file_identifier(model_converter_exe_path, tmp_path):
+    input_mlir = tmp_path / "input.mlir"
+    input_flatbuffer = tmp_path / "input.bin"
+    output_vgf = tmp_path / "output.vgf"
+    input_mlir.write_text(direct_passthrough_mlir())
+
+    subprocess.run(
+        [
+            model_converter_exe_path,
+            "--tosa-flatbuffer",
+            "--input",
+            input_mlir,
+            "--output",
+            input_flatbuffer,
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            model_converter_exe_path,
+            "--input",
+            input_flatbuffer,
+            "--output",
+            output_vgf,
+        ],
+        check=True,
+    )
+
+    assert output_vgf.stat().st_size > 0
 
 
 def conv2d_mlir():


### PR DESCRIPTION
Inspect the schema-defined "TOSA" FlatBuffer identifier instead of relying on the input filename extension. This allows files such as `.tosa.fb` or `.bin` to be deserialized correctly.