### PR TITLE
chore: clang-tidy findings in model-converter headers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -92,7 +92,6 @@ Checks: >
     readability-use-anyofallof,
 
 WarningsAsErrors: '*'
-HeaderFilterRegex: '.*'
 FormatStyle: file
 CheckOptions:
   - key: bugprone-unsafe-functions.ReportDefaultFunctions

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -278,6 +278,7 @@ class Builder:
 
                 clang_tidy_cmd = [
                     "run-clang-tidy",
+                    "-header-filter=model-converter/src/.*",
                     "-quiet",
                     f"-j{self.threads}",
                     f"-p{self.build_dir}",


### PR DESCRIPTION
Pass header filtering explicitly to run-clang-tidy to work around the HeaderFilterRegex configuration bug in clang-tidy 20.1.2.